### PR TITLE
Tweak segment encoding to keep memory/table index

### DIFF
--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -330,6 +330,9 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
    \production{element segment} & \Belem &::=&
      \hex{01}~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \{ \EINIT~y^\ast \} \\
+   \production{element segment} & \Belem &::=&
+     \hex{02}~~x{:}\Btableidx~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
+       &\Rightarrow& \{ \ETABLE~x, \EOFFSET~e, \EINIT~y^\ast \} \\
    \end{array}
 
 .. note::
@@ -419,6 +422,9 @@ It decodes into a vector of :ref:`data segments <syntax-data>` that represent th
    \production{data segment} & \Bdata &::=&
      \hex{01}~~b^\ast{:}\Bvec(\Bbyte)
        &\Rightarrow& \{ \DINIT~b^\ast \} \\
+   \production{data segment} & \Bdata &::=&
+     \hex{02}~~x{:}\Bmemidx~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
+       &\Rightarrow& \{ \DMEM~x, \DOFFSET~e, \DINIT~b^\ast \} \\
    \end{array}
 
 .. note::

--- a/proposals/bulk-memory-operations/Overview.md
+++ b/proposals/bulk-memory-operations/Overview.md
@@ -190,9 +190,10 @@ Attempting to drop an active segment is a validation error.
 The data section is encoded as follows:
 
 ```
-datasec ::= seg*:section_11(vec(data))   => seg
-data    ::= 0x00 e:expr b*:vec(byte)     => {data 0, offset e, init b*, active true}
-data    ::= 0x01 b*:vec(byte)            => {data 0, offset empty, init b*, active false}
+datasec ::= seg*:section_11(vec(data))        => seg
+data    ::= 0x00 e:expr b*:vec(byte)          => {data 0, offset e,     init b*, active true }
+data    ::= 0x01 b*:vec(byte)                 => {data 0, offset empty, init b*, active false}
+data    ::= 0x02 x:memidx e:expr b*:vec(byte) => {data x, offset e,     init b*, active true }
 ```
 
 The element section is encoded similarly.


### PR DESCRIPTION
The current state seems to remove the placeholder table/memory index from the encoding to use it as an active flag.

This change proposes to keep the table/memory index by designating an index of -1 to mean "inactive segment", with 0+ indexing the module's memories/tables.