### PR TITLE
Add a data declaration section to break code validation dependency on data section

### DIFF
--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -503,6 +503,7 @@
 .. |Belemsec| mathdef:: \xref{binary/modules}{binary-elemsec}{\B{elemsec}}
 .. |Bdatasec| mathdef:: \xref{binary/modules}{binary-datasec}{\B{datasec}}
 .. |Bstartsec| mathdef:: \xref{binary/modules}{binary-startsec}{\B{startsec}}
+.. |Bdatadeclsec| mathdef:: \xref{binary/modules}{binary-datadeclsec}{\B{datadeclsec}}
 
 .. |Bcustom| mathdef:: \xref{binary/modules}{binary-customsec}{\B{custom}}
 .. |Btype| mathdef:: \xref{binary/modules}{binary-typedef}{\B{type}}
@@ -515,9 +516,12 @@
 .. |Bimportdesc| mathdef:: \xref{binary/modules}{binary-importdesc}{\B{importdesc}}
 .. |Bexportdesc| mathdef:: \xref{binary/modules}{binary-exportdesc}{\B{exportdesc}}
 .. |Belem| mathdef:: \xref{binary/modules}{binary-elem}{\B{elem}}
+.. |Bsegtype| mathdef:: \xref{binary/modules}{binary-datadecl}{\B{segtype}}
 .. |Bcode| mathdef:: \xref{binary/modules}{binary-code}{\B{code}}
 .. |Blocal| mathdef:: \xref{binary/modules}{binary-local}{\B{local}}
 .. |Blocals| mathdef:: \xref{binary/modules}{binary-local}{\B{locals}}
+.. |Bdatasecbody| mathdef:: \xref{binary/modules}{binary-datasecbody}{\B{datasecbody}}
+.. |Bdatavec| mathdef:: \xref{binary/modules}{binary-datavec}{\B{datavec}}
 .. |Bdata| mathdef:: \xref{binary/modules}{binary-data}{\B{data}}
 .. |Bstart| mathdef:: \xref{binary/modules}{binary-start}{\B{start}}
 


### PR DESCRIPTION
As mentioned in #27, this allows streaming validation of `mem.init` and `mem.drop` by adding data declaration sections that may occur before the code section, and must be used to declare a passive data segment.

I've uploaded the HTML build of the modified spec here: https://www.scheidecker.net/2018-09-07-data-declaration-section-spec/binary/modules.html#data-declaration-section

I think the `\Bdatavec` and `\Bdata` productions are a bit informal, so if folks like the overall direction of this change, I'd appreciate some suggestions on how to write those.