### PR TITLE
Clarify `*.init` can be used with active segments

### DIFF
--- a/proposals/bulk-memory-operations/Overview.md
+++ b/proposals/bulk-memory-operations/Overview.md
@@ -243,8 +243,9 @@ TODO: coordinate with other proposals to determine the binary encoding for `ref.
 
 ### `memory.init` instruction
 
-The `memory.init` instruction copies data from a given passive segment into a target
-memory. The target memory and source segment are given as immediates.
+The `memory.init` instruction copies data from a given segment into a target
+memory. The specified segment can be either active or passive. The target memory
+and source segment are given as immediates.
 
 The instruction has the signature `[i32 i32 i32] -> []`. The parameters are, in order:
 


### PR DESCRIPTION
On rereading the text of the proposal I *think* this is the intent.
Currently it reads as if `memory.init` and `table.init` can only be used
on passive segments, but the `DataCount` section I believe counts all
data segments, both active and passive, so when verifying function
bodies a segment index isn't known whether to be active or passive.