### PR TITLE
[interpreter] Flatten segment AST

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -611,20 +611,17 @@ let segment dat s =
   | 0l ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
-    let sdesc = Active {index; offset} in
     let init = dat s in
-    {sdesc; init}
+    Active {index; offset; init}
   | 1l ->
-    let sdesc = Passive in
     let init = dat s in
-    {sdesc; init}
+    Passive init
   | 2l ->
     let index = at var s in
     let offset = const s in
-    let sdesc = Active {index; offset} in
     let init = dat s in
-    {sdesc; init}
-  | _ -> error s (pos s - 1) "invalid segment flags"
+    Active {index; offset; init}
+  | _ -> error s (pos s - 1) "invalid segment kind"
 
 let table_segment s =
   segment (vec (at var)) s

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -478,9 +478,8 @@ let encode m =
 
     (* Element section *)
     let segment dat seg =
-      let {sdesc; init} = seg.it in
-      match sdesc with
-      | Active {index; offset} ->
+      match seg.it with
+      | Active {index; offset; init} ->
         if index.it = 0l then
           u8 0x00
         else begin
@@ -488,8 +487,8 @@ let encode m =
         end;
         const offset;
         dat init
-      | Passive ->
-          u8 0x01; dat init
+      | Passive init ->
+        u8 0x01; dat init
 
     let table_segment seg =
       segment (vec var) seg

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -388,9 +388,8 @@ let init_func (inst : module_inst) (func : func_inst) =
   | _ -> assert false
 
 let init_table (inst : module_inst) (seg : table_segment) =
-  let {sdesc; init} = seg.it in
-  match sdesc with
-  | Active {index; offset = const} ->
+  match seg.it with
+  | Active {index; offset = const; init} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
     let end_ = Int32.(add offset (of_int (List.length init))) in
@@ -399,12 +398,11 @@ let init_table (inst : module_inst) (seg : table_segment) =
       Link.error seg.at "elements segment does not fit table";
     fun () ->
       Table.blit tab offset (List.map (fun x -> FuncElem (func inst x)) init)
-  | Passive -> fun () -> ()
+  | Passive init -> fun () -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =
-  let {sdesc; init} = seg.it in
-  match sdesc with
-  | Active {index; offset = const} ->
+  match seg.it with
+  | Active {index; offset = const; init} ->
     let mem = memory inst index in
     let offset' = i32 (eval_const inst const) const.at in
     let offset = I64_convert.extend_u_i32 offset' in
@@ -413,7 +411,7 @@ let init_memory (inst : module_inst) (seg : memory_segment) =
     if I64.lt_u bound end_ || I64.lt_u end_ offset then
       Link.error seg.at "data segment does not fit memory";
     fun () -> Memory.store_bytes mem offset init
-  | Passive -> fun () -> ()
+  | Passive init -> fun () -> ()
 
 
 let add_import (m : module_) (ext : extern) (im : import) (inst : module_inst)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -110,10 +110,6 @@ and instr' =
 
 type const = instr list Source.phrase
 
-type segment_desc =
-  | Active of {index : var; offset : const}
-  | Passive
-
 type global = global' Source.phrase
 and global' =
 {
@@ -146,10 +142,8 @@ and memory' =
 
 type 'data segment = 'data segment' Source.phrase
 and 'data segment' =
-{
-  sdesc : segment_desc;
-  init : 'data;
-}
+  | Active of {index : var; offset : const; init : 'data}
+  | Passive of 'data
 
 type table_segment = var list segment
 type memory_segment = string segment

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -201,11 +201,10 @@ let f64_reinterpret_i64 = Convert (F64 F64Op.ReinterpretInt)
 
 let memory_size = MemorySize
 let memory_grow = MemoryGrow
-
 let memory_init x = MemoryInit x
-let data_drop x = DataDrop x
 let memory_copy = MemoryCopy
 let memory_fill = MemoryFill
 let table_init x = TableInit x
-let elem_drop x = ElemDrop x
 let table_copy = TableCopy
+let data_drop x = DataDrop x
+let elem_drop x = ElemDrop x

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -10,12 +10,12 @@ type mutability = Immutable | Mutable
 type table_type = TableType of Int32.t limits * elem_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
+type segment_type = SegmentType
 type extern_type =
   | ExternFuncType of func_type
   | ExternTableType of table_type
   | ExternMemoryType of memory_type
   | ExternGlobalType of global_type
-type segment_type = Seg
 
 
 (* Attributes *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -297,11 +297,10 @@ let memory off i mem =
   Node ("memory $" ^ nat (off + i) ^ " " ^ limits nat32 lim, [])
 
 let segment head dat seg =
-  let {sdesc; init} = seg.it in
-  match sdesc with
-  | Active {index; offset} ->
+  match seg.it with
+  | Active {index; offset; init} ->
     Node (head, atom var index :: Node ("offset", const offset) :: dat init)
-  | Passive -> Node (head, dat init)
+  | Passive init -> Node (head, dat init)
 
 let elems seg =
   segment "elem" (list (atom var)) seg

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -428,21 +428,20 @@ let check_memory (c : context) (mem : memory) =
   check_memory_type mtype mem.at
 
 let check_elem (c : context) (seg : table_segment) =
-  let {sdesc; init} = seg.it in
-  ignore (List.map (func c) init);
-  match sdesc with
-  | Active {index; offset} ->
+  match seg.it with
+  | Active {index; offset; init} ->
+    ignore (table c index);
     check_const c offset I32Type;
-    ignore (table c index)
-  | Passive -> ()
+    ignore (List.map (func c) init)
+  | Passive init ->
+    ignore (List.map (func c) init)
 
 let check_data (c : context) (seg : memory_segment) =
-  let {sdesc; init} = seg.it in
-  match sdesc with
-  | Active {index; offset} ->
-    check_const c offset I32Type;
-    ignore (memory c index)
-  | Passive -> ()
+  match seg.it with
+  | Active {index; offset; init} ->
+    ignore (memory c index);
+    check_const c offset I32Type
+  | Passive init -> ()
 
 let check_global (c : context) (glob : global) =
   let {gtype; value} = glob.it in
@@ -506,8 +505,8 @@ let check_module (m : module_) =
       funcs = c0.funcs @ List.map (fun f -> type_ c0 f.it.ftype) funcs;
       tables = c0.tables @ List.map (fun tab -> tab.it.ttype) tables;
       memories = c0.memories @ List.map (fun mem -> mem.it.mtype) memories;
-      elems = List.map (fun elem -> Seg) elems;
-      data = List.map (fun data -> Seg) data;
+      elems = List.map (fun elem -> SegmentType) elems;
+      data = List.map (fun data -> SegmentType) data;
     }
   in
   let c =


### PR DESCRIPTION
I realised that it's simpler to just flatten segment_desc and segment into one type.