### PR TITLE
[Interpreter] Handle 0-byte copies properly.

### DIFF
--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -145,7 +145,7 @@ let store_packed sz mem a o v =
     | _ -> raise Type
   in storen mem a o n x
 
-let check_bounds mem a = if I64.ge_u a (bound mem) then raise Bounds
+let check_bounds mem a = if I64.gt_u a (bound mem) then raise Bounds
 
 let fill mem a v n =
   let rec loop a n =
@@ -153,7 +153,8 @@ let fill mem a v n =
       store_byte mem a v;
       loop (Int64.add a 1L) (Int32.sub n 1l)
     end
-  in check_bounds mem a; loop a n
+  in loop a n;
+  check_bounds mem Int64.(add a (of_int32 n))
 
 let copy mem d s n =
   let n' = Int64.of_int32 n in
@@ -163,10 +164,9 @@ let copy mem d s n =
       store_byte mem d (load_byte mem s);
       loop (Int64.add d dx) (Int64.add s dx) (Int32.sub n 1l) dx
     end
-  in
-  check_bounds mem d;
-  check_bounds mem s;
-  if overlap && s < d then
+  in (if overlap && s < d then
     loop Int64.(add d (sub n' 1L)) Int64.(add s (sub n' 1L)) n (-1L)
   else
-    loop d s n 1L
+    loop d s n 1L);
+  check_bounds mem (Int64.add d n');
+  check_bounds mem (Int64.add s n')

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -33,8 +33,11 @@
 (assert_return (invoke "load8_u" (i32.const 0xff00)) (i32.const 1))
 (assert_return (invoke "load8_u" (i32.const 0xffff)) (i32.const 1))
 
-;; Fail on out-of-bounds even if filling 0 bytes.
-(assert_trap (invoke "fill" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+;; Succeed when writing 0 bytes at the end of the region.
+(invoke "fill" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+
+;; Fail on out-of-bounds when writing 0 bytes outside of memory.
+(assert_trap (invoke "fill" (i32.const 0x10001) (i32.const 0) (i32.const 0))
     "out of bounds memory access")
 
 
@@ -90,8 +93,12 @@
 (assert_return (invoke "load8_u" (i32.const 0xfffe)) (i32.const 0xaa))
 (assert_return (invoke "load8_u" (i32.const 0xffff)) (i32.const 0xbb))
 
-;; Fail on out-of-bounds even if copying 0 bytes.
-(assert_trap (invoke "copy" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+;; Succeed when copying 0 bytes at the end of the region.
+(invoke "copy" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+(invoke "copy" (i32.const 0) (i32.const 0x10000) (i32.const 0))
+
+;; Fail on out-of-bounds when copying 0 bytes outside of memory.
+(assert_trap (invoke "copy" (i32.const 0x10001) (i32.const 0) (i32.const 0))
     "out of bounds memory access")
-(assert_trap (invoke "copy" (i32.const 0) (i32.const 0x10000) (i32.const 0))
+(assert_trap (invoke "copy" (i32.const 0) (i32.const 0x10001) (i32.const 0))
     "out of bounds memory access")


### PR DESCRIPTION
Similar to the MVP, a 0-byte access at the end of the region is legal.