### PR TITLE
[Interpreter] Initialized segments persist after instantiation failure

### DIFF
--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -145,7 +145,7 @@ let store_packed sz mem a o v =
     | _ -> raise Type
   in storen mem a o n x
 
-let check_bounds mem a = if I64.ge_u a (bound mem) then raise Bounds
+let check_bounds mem a = if I64.gt_u a (bound mem) then raise Bounds
 
 let fill mem a v n =
   let rec loop a n =
@@ -153,7 +153,8 @@ let fill mem a v n =
       store_byte mem a v;
       loop (Int64.add a 1L) (Int32.sub n 1l)
     end
-  in check_bounds mem a; loop a n
+  in loop a n;
+  check_bounds mem Int64.(add a (of_int32 n))
 
 let copy mem d s n =
   let n' = Int64.of_int32 n in
@@ -163,10 +164,9 @@ let copy mem d s n =
       store_byte mem d (load_byte mem s);
       loop (Int64.add d dx) (Int64.add s dx) (Int32.sub n 1l) dx
     end
-  in
-  check_bounds mem d;
-  check_bounds mem s;
-  if overlap && s < d then
+  in (if overlap && s < d then
     loop Int64.(add d (sub n' 1L)) Int64.(add s (sub n' 1L)) n (-1L)
   else
-    loop d s n 1L
+    loop d s n 1L);
+  check_bounds mem (Int64.add d n');
+  check_bounds mem (Int64.add s n')

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -70,6 +70,18 @@ let load_byte mem a =
 let store_byte mem a b =
   try Array1_64.set mem.content a b with Invalid_argument _ -> raise Bounds
 
+let load_bytes mem a n =
+  let buf = Buffer.create n in
+  for i = 0 to n - 1 do
+    Buffer.add_char buf (Char.chr (load_byte mem Int64.(add a (of_int i))))
+  done;
+  Buffer.contents buf
+
+let store_bytes mem a bs =
+  for i = String.length bs - 1 downto 0 do
+    store_byte mem Int64.(add a (of_int i)) (Char.code bs.[i])
+  done
+
 let effective_address a o =
   let ea = Int64.(add a (of_int32 o)) in
   if I64.lt_u ea a then raise Bounds;

--- a/interpreter/runtime/memory.mli
+++ b/interpreter/runtime/memory.mli
@@ -30,8 +30,6 @@ val grow : memory -> size -> unit
 
 val load_byte : memory -> address -> int (* raises Bounds *)
 val store_byte : memory -> address -> int -> unit (* raises Bounds *)
-val load_bytes : memory -> address -> int -> string (* raises Bounds *)
-val store_bytes : memory -> address -> string -> unit (* raises Bounds *)
 
 val load_value :
   memory -> address -> offset -> value_type -> value (* raises Bounds *)
@@ -44,5 +42,6 @@ val store_packed :
   pack_size -> memory -> address -> offset -> value -> unit
     (* raises Type, Bounds *)
 
-val fill : memory -> address -> int -> count -> unit (* raises Bounds *)
+val init : memory -> address -> string -> unit (* raises Bounds *)
 val copy : memory -> address -> address -> count -> unit (* raises Bounds *)
+val fill : memory -> address -> int -> count -> unit (* raises Bounds *)

--- a/interpreter/runtime/memory.mli
+++ b/interpreter/runtime/memory.mli
@@ -30,6 +30,8 @@ val grow : memory -> size -> unit
 
 val load_byte : memory -> address -> int (* raises Bounds *)
 val store_byte : memory -> address -> int -> unit (* raises Bounds *)
+val load_bytes : memory -> address -> int -> string (* raises Bounds *)
+val store_bytes : memory -> address -> string -> unit (* raises Bounds *)
 
 val load_value :
   memory -> address -> offset -> value_type -> value (* raises Bounds *)

--- a/interpreter/runtime/table.ml
+++ b/interpreter/runtime/table.ml
@@ -48,7 +48,8 @@ let load tab i =
 let store tab i v =
   try Lib.Array32.set tab.content i v with Invalid_argument _ -> raise Bounds
 
-let blit tab offset elems =
-  let data = Array.of_list elems in
-  try Lib.Array32.blit data 0l tab.content offset (Lib.Array32.length data)
-  with Invalid_argument _ -> raise Bounds
+let check_bounds tab i = if I32.gt_u i (size tab) then raise Bounds
+
+let init tab offset elems =
+  List.iteri (fun i -> store tab (Int32.(add offset (of_int i)))) elems;
+  check_bounds tab Int32.(add offset (of_int (List.length elems)))

--- a/interpreter/runtime/table.mli
+++ b/interpreter/runtime/table.mli
@@ -20,4 +20,5 @@ val grow : table -> size -> unit (* raises SizeOverflow, SizeLimit *)
 
 val load : table -> index -> elem (* raises Bounds *)
 val store : table -> index -> elem -> unit (* raises Bounds *)
-val blit : table -> index -> elem list -> unit (* raises Bounds *)
+
+val init : table -> index -> elem list -> unit (* raises Bounds *)

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -33,8 +33,11 @@
 (assert_return (invoke "load8_u" (i32.const 0xff00)) (i32.const 1))
 (assert_return (invoke "load8_u" (i32.const 0xffff)) (i32.const 1))
 
-;; Fail on out-of-bounds even if filling 0 bytes.
-(assert_trap (invoke "fill" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+;; Succeed when writing 0 bytes at the end of the region.
+(invoke "fill" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+
+;; Fail on out-of-bounds when writing 0 bytes outside of memory.
+(assert_trap (invoke "fill" (i32.const 0x10001) (i32.const 0) (i32.const 0))
     "out of bounds memory access")
 
 
@@ -90,8 +93,12 @@
 (assert_return (invoke "load8_u" (i32.const 0xfffe)) (i32.const 0xaa))
 (assert_return (invoke "load8_u" (i32.const 0xffff)) (i32.const 0xbb))
 
-;; Fail on out-of-bounds even if copying 0 bytes.
-(assert_trap (invoke "copy" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+;; Succeed when copying 0 bytes at the end of the region.
+(invoke "copy" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+(invoke "copy" (i32.const 0) (i32.const 0x10000) (i32.const 0))
+
+;; Fail on out-of-bounds when copying 0 bytes outside of memory.
+(assert_trap (invoke "copy" (i32.const 0x10001) (i32.const 0) (i32.const 0))
     "out of bounds memory access")
-(assert_trap (invoke "copy" (i32.const 0) (i32.const 0x10000) (i32.const 0))
+(assert_trap (invoke "copy" (i32.const 0) (i32.const 0x10001) (i32.const 0))
     "out of bounds memory access")

--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -224,6 +224,8 @@
 )
 (assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
 
+;; Unlike in the v1 spec, the elements stored before an out-of-bounds access
+;; persist after the instantiation failure.
 (assert_unlinkable
   (module
     (table (import "Mt" "tab") 10 funcref)
@@ -233,7 +235,7 @@
   )
   "elements segment does not fit"
 )
-(assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
+(assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
 
 (assert_unlinkable
   (module
@@ -245,7 +247,7 @@
   )
   "data segment does not fit"
 )
-(assert_trap (invoke $Mt "call" (i32.const 7)) "uninitialized")
+(assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
 
 
 ;; Memories
@@ -331,6 +333,8 @@
 )
 (assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))
 
+;; Unlike in v1 spec, bytes written before an out-of-bounds access persist
+;; after the instantiation failure.
 (assert_unlinkable
   (module
     (memory (import "Mm" "mem") 1)
@@ -339,7 +343,7 @@
   )
   "data segment does not fit"
 )
-(assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))
+(assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 97))
 
 (assert_unlinkable
   (module
@@ -351,4 +355,4 @@
   )
   "elements segment does not fit"
 )
-(assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 0))
+(assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 97))


### PR DESCRIPTION
This behavior is a breaking change from the v1 spec, but it is unlikely
that any programs depend on it.