### PR TITLE
[Interpreter] Implement rest of the instructions

### DIFF
--- a/interpreter/runtime/instance.ml
+++ b/interpreter/runtime/instance.ml
@@ -8,6 +8,8 @@ type module_inst =
   memories : memory_inst list;
   globals : global_inst list;
   exports : export_inst list;
+  elems : elems_inst list;
+  data : data_inst list;
 }
 
 and func_inst = module_inst ref Func.t
@@ -15,6 +17,8 @@ and table_inst = Table.t
 and memory_inst = Memory.t
 and global_inst = Global.t
 and export_inst = Ast.name * extern
+and elems_inst = Table.elem list option ref
+and data_inst = string option ref
 
 and extern =
   | ExternFunc of func_inst
@@ -29,7 +33,7 @@ type Table.elem += FuncElem of func_inst
 
 let empty_module_inst =
   { types = []; funcs = []; tables = []; memories = []; globals = [];
-    exports = [] }
+    exports = []; elems = []; data = [] }
 
 let extern_type_of = function
   | ExternFunc func -> ExternFuncType (Func.type_of func)

--- a/interpreter/runtime/memory.ml
+++ b/interpreter/runtime/memory.ml
@@ -145,13 +145,23 @@ let store_packed sz mem a o v =
     | _ -> raise Type
   in storen mem a o n x
 
+let check_str_bounds bs a =
+  if I64.gt_u a (Int64.of_int (String.length bs)) then raise Bounds
+
 let check_bounds mem a = if I64.gt_u a (bound mem) then raise Bounds
 
-let init mem a bs =
-  for i = 0 to String.length bs - 1 do
-    store_byte mem Int64.(add a (of_int i)) (Char.code bs.[i])
-  done;
-  check_bounds mem Int64.(add a (of_int (String.length bs)))
+let init mem bs d s n =
+  let n' = Int64.of_int32 n in
+  let rec loop d s n =
+    if n > 0l then begin
+      check_str_bounds bs s;
+      let b = (Char.code bs.[Int64.to_int s]) in
+      store_byte mem d b;
+      loop (Int64.add d 1L) (Int64.add s 1L) (Int32.sub n 1l)
+    end
+  in loop d s n;
+  check_bounds mem (Int64.add d n');
+  check_str_bounds bs (Int64.add s n')
 
 let copy mem d s n =
   let n' = Int64.of_int32 n in

--- a/interpreter/runtime/memory.mli
+++ b/interpreter/runtime/memory.mli
@@ -44,6 +44,7 @@ val store_packed :
   pack_size -> memory -> address -> offset -> value -> unit
     (* raises Type, Bounds *)
 
-val init : memory -> address -> string -> unit (* raises Bounds *)
+val init :
+  memory -> string -> address -> address -> count -> unit (* raises Bounds *)
 val copy : memory -> address -> address -> count -> unit (* raises Bounds *)
 val fill : memory -> address -> int -> count -> unit (* raises Bounds *)

--- a/interpreter/runtime/table.mli
+++ b/interpreter/runtime/table.mli
@@ -5,6 +5,7 @@ type t = table
 
 type size = int32
 type index = int32
+type count = int32
 
 type elem = ..
 type elem += Uninitialized
@@ -21,4 +22,6 @@ val grow : table -> size -> unit (* raises SizeOverflow, SizeLimit *)
 val load : table -> index -> elem (* raises Bounds *)
 val store : table -> index -> elem -> unit (* raises Bounds *)
 
-val init : table -> index -> elem list -> unit (* raises Bounds *)
+val init :
+  table -> elem list -> index -> index -> count -> unit (* raises Bounds *)
+val copy : table -> index -> index -> count -> unit (* raises Bounds *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -300,7 +300,7 @@ let segment head dat seg =
   match seg.it with
   | Active {index; offset; init} ->
     Node (head, atom var index :: Node ("offset", const offset) :: dat init)
-  | Passive init -> Node (head, dat init)
+  | Passive init -> Node (head ^ " passive", dat init)
 
 let elems seg =
   segment "elem" (list (atom var)) seg

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -1,3 +1,4 @@
+;; memory.fill
 (module
   (memory 1)
 
@@ -41,6 +42,7 @@
     "out of bounds memory access")
 
 
+;; memory.copy
 (module
   (memory (data "\aa\bb\cc\dd"))
 
@@ -102,3 +104,193 @@
     "out of bounds memory access")
 (assert_trap (invoke "copy" (i32.const 0) (i32.const 0x10001) (i32.const 0))
     "out of bounds memory access")
+
+
+;; memory.init
+(module
+  (memory 1)
+  (data passive "\aa\bb\cc\dd")
+
+  (func (export "init") (param i32 i32 i32)
+    (memory.init 0
+      (local.get 0)
+      (local.get 1)
+      (local.get 2)))
+
+  (func (export "load8_u") (param i32) (result i32)
+    (i32.load8_u (local.get 0)))
+)
+
+(invoke "init" (i32.const 0) (i32.const 1) (i32.const 2))
+(assert_return (invoke "load8_u" (i32.const 0)) (i32.const 0xbb))
+(assert_return (invoke "load8_u" (i32.const 1)) (i32.const 0xcc))
+(assert_return (invoke "load8_u" (i32.const 2)) (i32.const 0))
+
+;; Init ending at memory limit and segment limit is ok.
+(invoke "init" (i32.const 0xfffc) (i32.const 0) (i32.const 4))
+
+;; Out-of-bounds writes trap, but all previous writes succeed.
+(assert_trap (invoke "init" (i32.const 0xfffe) (i32.const 0) (i32.const 3))
+    "out of bounds memory access")
+(assert_return (invoke "load8_u" (i32.const 0xfffe)) (i32.const 0xaa))
+(assert_return (invoke "load8_u" (i32.const 0xffff)) (i32.const 0xbb))
+
+;; Succeed when writing 0 bytes at the end of either region.
+(invoke "init" (i32.const 0x10000) (i32.const 0) (i32.const 0))
+(invoke "init" (i32.const 0) (i32.const 4) (i32.const 0))
+
+;; Fail on out-of-bounds when writing 0 bytes outside of memory or segment.
+(assert_trap (invoke "init" (i32.const 0x10001) (i32.const 0) (i32.const 0))
+    "out of bounds memory access")
+(assert_trap (invoke "init" (i32.const 0) (i32.const 5) (i32.const 0))
+    "out of bounds memory access")
+
+;; data.drop
+(module
+  (memory 1)
+  (data $p passive "")
+  (data $a 0 (i32.const 0) "")
+
+  (func (export "drop_passive") (data.drop $p))
+  (func (export "init_passive")
+    (memory.init $p (i32.const 0) (i32.const 0) (i32.const 0)))
+
+  (func (export "drop_active") (data.drop $a))
+  (func (export "init_active")
+    (memory.init $a (i32.const 0) (i32.const 0) (i32.const 0)))
+)
+
+(invoke "init_passive")
+(invoke "drop_passive")
+(assert_trap (invoke "drop_passive") "data segment dropped")
+(assert_trap (invoke "init_passive") "data segment dropped")
+(assert_trap (invoke "drop_active") "data segment dropped")
+(assert_trap (invoke "init_active") "data segment dropped")
+
+
+;; table.init
+(module
+  (table 3 funcref)
+  (elem passive $zero $one $zero $one)
+
+  (func $zero (result i32) (i32.const 0))
+  (func $one (result i32) (i32.const 1))
+
+  (func (export "init") (param i32 i32 i32)
+    (table.init 0
+      (local.get 0)
+      (local.get 1)
+      (local.get 2)))
+
+  (func (export "call") (param i32) (result i32)
+    (call_indirect (result i32)
+      (local.get 0)))
+)
+
+(invoke "init" (i32.const 0) (i32.const 1) (i32.const 2))
+(assert_return (invoke "call" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "call" (i32.const 1)) (i32.const 0))
+(assert_trap (invoke "call" (i32.const 2)) "uninitialized element")
+
+;; Init ending at table limit and segment limit is ok.
+(invoke "init" (i32.const 1) (i32.const 2) (i32.const 2))
+
+;; Out-of-bounds stores trap, but all previous stores succeed.
+(assert_trap (invoke "init" (i32.const 2) (i32.const 0) (i32.const 2))
+    "out of bounds table access")
+(assert_return (invoke "call" (i32.const 2)) (i32.const 0))
+
+;; Succeed when storing 0 elements at the end of either region.
+(invoke "init" (i32.const 3) (i32.const 0) (i32.const 0))
+(invoke "init" (i32.const 0) (i32.const 4) (i32.const 0))
+
+;; Fail on out-of-bounds when storing 0 elements outside of table or segment.
+(assert_trap (invoke "init" (i32.const 4) (i32.const 0) (i32.const 0))
+    "out of bounds table access")
+(assert_trap (invoke "init" (i32.const 0) (i32.const 5) (i32.const 0))
+    "out of bounds table access")
+
+
+;; elem.drop
+(module
+  (table 1 funcref)
+  (func $f)
+  (elem $p passive $f)
+  (elem $a 0 (i32.const 0) $f)
+
+  (func (export "drop_passive") (elem.drop $p))
+  (func (export "init_passive")
+    (table.init $p (i32.const 0) (i32.const 0) (i32.const 0)))
+
+  (func (export "drop_active") (elem.drop $a))
+  (func (export "init_active")
+    (table.init $a (i32.const 0) (i32.const 0) (i32.const 0)))
+)
+
+(invoke "init_passive")
+(invoke "drop_passive")
+(assert_trap (invoke "drop_passive") "elements segment dropped")
+(assert_trap (invoke "init_passive") "elements segment dropped")
+(assert_trap (invoke "drop_active") "elements segment dropped")
+(assert_trap (invoke "init_active") "elements segment dropped")
+
+
+;; table.copy
+(module
+  (table 10 funcref)
+  (elem (i32.const 0) $zero $one $two)
+  (func $zero (result i32) (i32.const 0))
+  (func $one (result i32) (i32.const 1))
+  (func $two (result i32) (i32.const 2))
+
+  (func (export "copy") (param i32 i32 i32)
+    (table.copy
+      (local.get 0)
+      (local.get 1)
+      (local.get 2)))
+
+  (func (export "call") (param i32) (result i32)
+    (call_indirect (result i32)
+      (local.get 0)))
+)
+
+;; Non-overlapping copy.
+(invoke "copy" (i32.const 3) (i32.const 0) (i32.const 3))
+;; Now [$zero, $one, $two, $zero, $one, $two, ...]
+(assert_return (invoke "call" (i32.const 3)) (i32.const 0))
+(assert_return (invoke "call" (i32.const 4)) (i32.const 1))
+(assert_return (invoke "call" (i32.const 5)) (i32.const 2))
+
+;; Overlap, source > dest
+(invoke "copy" (i32.const 0) (i32.const 1) (i32.const 3))
+;; Now [$one, $two, $zero, $zero, $one, $two, ...]
+(assert_return (invoke "call" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "call" (i32.const 1)) (i32.const 2))
+(assert_return (invoke "call" (i32.const 2)) (i32.const 0))
+
+;; Overlap, source < dest
+(invoke "copy" (i32.const 2) (i32.const 0) (i32.const 3))
+;; Now [$one, $two, $one, $two, $zero, $two, ...]
+(assert_return (invoke "call" (i32.const 2)) (i32.const 1))
+(assert_return (invoke "call" (i32.const 3)) (i32.const 2))
+(assert_return (invoke "call" (i32.const 4)) (i32.const 0))
+
+;; Copy ending at table limit is ok.
+(invoke "copy" (i32.const 6) (i32.const 8) (i32.const 2))
+(invoke "copy" (i32.const 8) (i32.const 6) (i32.const 2))
+
+;; Out-of-bounds writes trap, but all previous writes succeed.
+(assert_trap (invoke "call" (i32.const 9)) "uninitialized element")
+(assert_trap (invoke "copy" (i32.const 9) (i32.const 0) (i32.const 2))
+    "out of bounds table access")
+(assert_return (invoke "call" (i32.const 9)) (i32.const 1))
+
+;; Succeed when copying 0 elements at the end of the region.
+(invoke "copy" (i32.const 10) (i32.const 0) (i32.const 0))
+(invoke "copy" (i32.const 0) (i32.const 10) (i32.const 0))
+
+;; Fail on out-of-bounds when copying 0 elements outside of table.
+(assert_trap (invoke "copy" (i32.const 11) (i32.const 0) (i32.const 0))
+    "out of bounds table access")
+(assert_trap (invoke "copy" (i32.const 0) (i32.const 11) (i32.const 0))
+    "out of bounds table access")


### PR DESCRIPTION
`memory.init`, `data.drop`, `table.init`, `elem.drop`, `table.copy`

Also fix writing passive segments in the text format.