### PR TITLE
[Interpreter] New syntax for passive elem segments

### DIFF
--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -477,7 +477,7 @@ let encode m =
       section 10 (vec code) fs (fs <> [])
 
     (* Element section *)
-    let segment dat seg =
+    let segment active passive seg =
       match seg.it with
       | Active {index; offset; init} ->
         if index.it = 0l then
@@ -486,19 +486,29 @@ let encode m =
           u8 0x02; var index
         end;
         const offset;
-        dat init
+        active init
       | Passive init ->
-        u8 0x01; dat init
+        u8 0x01; passive init
+
+    let active_elem el =
+      match el.it with
+      | Null -> assert false
+      | Func x -> var x
+
+    let passive_elem el =
+      match el.it with
+      | Null -> u8 0xd0; end_ ()
+      | Func x -> u8 0xd2; var x; end_ ()
 
     let table_segment seg =
-      segment (vec var) seg
+      segment (vec active_elem) (vec passive_elem) seg
 
     let elem_section elems =
       section 9 (vec table_segment) elems (elems <> [])
 
     (* Data section *)
     let memory_segment seg =
-      segment string seg
+      segment string string seg
 
     let data_section data =
       section 11 (vec memory_segment) data (data <> [])

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -436,7 +436,11 @@ let create_export (inst : module_inst) (ex : export) : export_inst =
   in name, ext
 
 let elems_list inst init =
-  List.map (fun x -> (FuncElem (func inst x))) init
+  let to_elem el =
+    match el.it with
+    | Null -> Table.Uninitialized
+    | Func x -> FuncElem (func inst x)
+  in List.map to_elem init
 
 let create_elems (inst : module_inst) (seg : table_segment) : elems_inst =
   match seg.it with

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -145,7 +145,12 @@ and 'data segment' =
   | Active of {index : var; offset : const; init : 'data}
   | Passive of 'data
 
-type table_segment = var list segment
+type elem = elem' Source.phrase
+and elem' =
+  | Null
+  | Func of var
+
+type table_segment = elem list segment
 type memory_segment = string segment
 
 
@@ -191,7 +196,7 @@ and module_' =
   memories : memory list;
   funcs : func list;
   start : var option;
-  elems : var list segment list;
+  elems : elem list segment list;
   data : string segment list;
   imports : import list;
   exports : export list;

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -296,17 +296,27 @@ let memory off i mem =
   let {mtype = MemoryType lim} = mem.it in
   Node ("memory $" ^ nat (off + i) ^ " " ^ limits nat32 lim, [])
 
-let segment head dat seg =
+let segment head active passive seg =
   match seg.it with
   | Active {index; offset; init} ->
-    Node (head, atom var index :: Node ("offset", const offset) :: dat init)
-  | Passive init -> Node (head ^ " passive", dat init)
+    Node (head, atom var index :: Node ("offset", const offset) :: active init)
+  | Passive init -> Node (head ^ " passive", passive init)
+
+let active_elem el =
+  match el.it with
+  | Null -> assert false
+  | Func x -> atom var x
+
+let passive_elem el =
+  match el.it with
+  | Null -> Node ("ref.null", [])
+  | Func x -> Node ("ref.func", [atom var x])
 
 let elems seg =
-  segment "elem" (list (atom var)) seg
+  segment "elem" (list active_elem) (list passive_elem) seg
 
 let data seg =
-  segment "data" break_bytes seg
+  segment "data" break_bytes break_bytes seg
 
 
 (* Modules *)

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -325,6 +325,9 @@ rule token = parse
   | "elem.drop" { ELEM_DROP }
   | "table.copy" { TABLE_COPY }
 
+  | "ref.null" { REF_NULL }
+  | "ref.func" { REF_FUNC }
+
   | "passive" { PASSIVE }
 
   | "type" { TYPE }

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -424,14 +424,19 @@ let check_memory (c : context) (mem : memory) =
   let {mtype} = mem.it in
   check_memory_type mtype mem.at
 
+let check_elemref (c : context) (el : elem) =
+  match el.it with
+  | Null -> ()
+  | Func x -> ignore (func c x)
+
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
   | Active {index; offset; init} ->
     ignore (table c index);
     check_const c offset I32Type;
-    ignore (List.map (func c) init)
+    List.iter (check_elemref c) init
   | Passive init ->
-    ignore (List.map (func c) init)
+    List.iter (check_elemref c) init
 
 let check_data (c : context) (seg : memory_segment) =
   match seg.it with

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -1,3 +1,14 @@
+;; Passive segment syntax
+(module
+  (memory 1)
+  (data passive "foo"))
+
+(module
+  (table 3 funcref)
+  (elem passive (ref.func 0) (ref.null) (ref.func 1))
+  (func)
+  (func))
+
 ;; memory.fill
 (module
   (memory 1)
@@ -171,7 +182,8 @@
 ;; table.init
 (module
   (table 3 funcref)
-  (elem passive $zero $one $zero $one)
+  (elem passive
+    (ref.func $zero) (ref.func $one) (ref.func $zero) (ref.func $one))
 
   (func $zero (result i32) (i32.const 0))
   (func $one (result i32) (i32.const 1))
@@ -215,7 +227,7 @@
 (module
   (table 1 funcref)
   (func $f)
-  (elem $p passive $f)
+  (elem $p passive (ref.func $f))
   (elem $a 0 (i32.const 0) $f)
 
   (func (export "drop_passive") (elem.drop $p))


### PR DESCRIPTION
It uses instruction encoding instead of assuming that each element is a
function variable:

```
0xd0 -> ref.null
0xd2 x -> ref.func x
```