### PR TITLE
[interpreter] Refactor element type in passive segments

### DIFF
--- a/interpreter/runtime/instance.ml
+++ b/interpreter/runtime/instance.ml
@@ -8,8 +8,8 @@ type module_inst =
   memories : memory_inst list;
   globals : global_inst list;
   exports : export_inst list;
-  elems : elems_inst list;
-  data : data_inst list;
+  elems : elem_inst list;
+  datas : data_inst list;
 }
 
 and func_inst = module_inst ref Func.t
@@ -17,7 +17,7 @@ and table_inst = Table.t
 and memory_inst = Memory.t
 and global_inst = Global.t
 and export_inst = Ast.name * extern
-and elems_inst = Table.elem list option ref
+and elem_inst = Table.elem list option ref
 and data_inst = string option ref
 
 and extern =
@@ -33,7 +33,7 @@ type Table.elem += FuncElem of func_inst
 
 let empty_module_inst =
   { types = []; funcs = []; tables = []; memories = []; globals = [];
-    exports = []; elems = []; data = [] }
+    exports = []; elems = []; datas = [] }
 
 let extern_type_of = function
   | ExternFunc func -> ExternFuncType (Func.type_of func)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -98,12 +98,12 @@ and instr' =
   | Binary of binop                   (* binary numeric operator *)
   | Convert of cvtop                  (* conversion *)
   | MemoryInit of var                 (* initialize memory from segment *)
-  | DataDrop of var                   (* drop passive data segment *)
   | MemoryCopy                        (* copy memory regions *)
   | MemoryFill                        (* fill memory region with value *)
   | TableInit of var                  (* initialize table from segment *)
-  | ElemDrop of var                   (* drop passive element segment *)
   | TableCopy                         (* copy elements between table regions *)
+  | DataDrop of var                   (* drop passive data segment *)
+  | ElemDrop of var                   (* drop passive element segment *)
 
 
 (* Globals & Functions *)
@@ -140,18 +140,18 @@ and memory' =
   mtype : memory_type;
 }
 
-type 'data segment = 'data segment' Source.phrase
-and 'data segment' =
+type ('data, 'ty) segment = ('data, 'ty) segment' Source.phrase
+and ('data, 'ty) segment' =
   | Active of {index : var; offset : const; init : 'data}
-  | Passive of 'data
+  | Passive of {etype : 'ty; data : 'data}
 
 type elem = elem' Source.phrase
 and elem' =
   | Null
   | Func of var
 
-type table_segment = (elem_type * (elem list)) segment
-type memory_segment = string segment
+type table_segment = (elem list, elem_type) segment
+type memory_segment = (string, unit) segment
 
 
 (* Modules *)
@@ -197,7 +197,7 @@ and module_' =
   funcs : func list;
   start : var option;
   elems : table_segment list;
-  data : memory_segment list;
+  datas : memory_segment list;
   imports : import list;
   exports : export list;
 }
@@ -213,8 +213,8 @@ let empty_module =
   memories = [];
   funcs = [];
   start = None;
-  elems  = [];
-  data = [];
+  elems = [];
+  datas = [];
   imports = [];
   exports = [];
 }

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -300,7 +300,7 @@ let segment head active passive seg =
   match seg.it with
   | Active {index; offset; init} ->
     Node (head, atom var index :: Node ("offset", const offset) :: active init)
-  | Passive init -> Node (head ^ " passive", passive init)
+  | Passive {etype; data} -> Node (head ^ " passive", passive etype data)
 
 let active_elem el =
   match el.it with
@@ -313,12 +313,12 @@ let passive_elem el =
   | Func x -> Node ("ref.func", [atom var x])
 
 let elems seg =
-  let active (_,init) = list active_elem init in
-  let passive (etype,init) = atom elem_type etype :: list passive_elem init in
+  let active init = list active_elem init in
+  let passive etype init = atom elem_type etype :: list passive_elem init in
   segment "elem" active passive seg
 
 let data seg =
-  segment "data" break_bytes break_bytes seg
+  segment "data" break_bytes (fun _ bs -> break_bytes bs) seg
 
 
 (* Modules *)
@@ -389,7 +389,7 @@ let module_with_var_opt x_opt m =
     list export m.it.exports @
     opt start m.it.start @
     list elems m.it.elems @
-    list data m.it.data
+    list data m.it.datas
   )
 
 let binary_module_with_var_opt x_opt bs =

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -678,7 +678,10 @@
     "\41\00"
     "\41\00"
     "\fc\08\00\00"             ;; memory.init
-    "\0b")                     ;; end
+    "\0b"
+
+    "\0b\03\01\01\00"          ;; Data section
+  )                            ;; end
   "data count section required")
 
 ;; data.drop requires a datacount section
@@ -694,7 +697,10 @@
     ;; function 0
     "\05\00"
     "\fc\09\00"                ;; data.drop
-    "\0b")                     ;; end
+    "\0b"
+
+    "\0b\03\01\01\00"          ;; Data section
+  )                            ;; end
   "data count section required")
 
 ;; passive element segment containing opcode other than ref.func or ref.null

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -241,10 +241,10 @@
 
 (invoke "init_passive")
 (invoke "drop_passive")
-(assert_trap (invoke "drop_passive") "elements segment dropped")
-(assert_trap (invoke "init_passive") "elements segment dropped")
-(assert_trap (invoke "drop_active") "elements segment dropped")
-(assert_trap (invoke "init_active") "elements segment dropped")
+(assert_trap (invoke "drop_passive") "element segment dropped")
+(assert_trap (invoke "init_passive") "element segment dropped")
+(assert_trap (invoke "drop_active") "element segment dropped")
+(assert_trap (invoke "init_active") "element segment dropped")
 
 
 ;; table.copy

--- a/test/core/table_init.wast
+++ b/test/core/table_init.wast
@@ -231,7 +231,7 @@
   (func (export "test")
     (elem.drop 2)
     ))
-(assert_trap (invoke "test") "elements segment dropped")
+(assert_trap (invoke "test") "element segment dropped")
 
 (module
   (table 30 30 funcref)
@@ -252,7 +252,7 @@
   (func (export "test")
     (table.init 2 (i32.const 12) (i32.const 1) (i32.const 1))
     ))
-(assert_trap (invoke "test") "elements segment dropped")
+(assert_trap (invoke "test") "element segment dropped")
 
 (module
   (table 30 30 funcref)
@@ -294,7 +294,7 @@
   (func (export "test")
     (elem.drop 1)
     (elem.drop 1)))
-(assert_trap (invoke "test") "elements segment dropped")
+(assert_trap (invoke "test") "element segment dropped")
 
 (module
   (table 30 30 funcref)
@@ -315,7 +315,7 @@
   (func (export "test")
     (elem.drop 1)
     (table.init 1 (i32.const 12) (i32.const 1) (i32.const 1))))
-(assert_trap (invoke "test") "elements segment dropped")
+(assert_trap (invoke "test") "element segment dropped")
 
 (module
   (table 30 30 funcref)


### PR DESCRIPTION
* Move a segment's element type into a separate record field for passive segments (only), avoiding dummy appearances in active segments.

* Fix a minor bug in encoding condition for data count section, which caused one test to fail.

* Check all global decoding side conditions in the same place.

* Minor naming consolidation.