### PR TITLE
Test reverse copy with out of bounds range

### DIFF
--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -96,6 +96,17 @@
 (assert_return (invoke "load8_u" (i32.const 15)) (i32.const 0xcc))
 (assert_return (invoke "load8_u" (i32.const 16)) (i32.const 0))
 
+;; Overlap, source < dest but top of region is out of bounds
+(assert_trap (invoke "copy" (i32.const 13) (i32.const 11) (i32.const -1))
+    "out of bounds memory access")
+(assert_return (invoke "load8_u" (i32.const 10)) (i32.const 0))
+(assert_return (invoke "load8_u" (i32.const 11)) (i32.const 0xaa))
+(assert_return (invoke "load8_u" (i32.const 12)) (i32.const 0xbb))
+(assert_return (invoke "load8_u" (i32.const 13)) (i32.const 0xcc))
+(assert_return (invoke "load8_u" (i32.const 14)) (i32.const 0xdd))
+(assert_return (invoke "load8_u" (i32.const 15)) (i32.const 0xcc))
+(assert_return (invoke "load8_u" (i32.const 16)) (i32.const 0))
+
 ;; Copy ending at memory limit is ok.
 (invoke "copy" (i32.const 0xff00) (i32.const 0) (i32.const 0x100))
 (invoke "copy" (i32.const 0xfe00) (i32.const 0xff00) (i32.const 0x100))


### PR DESCRIPTION
This covers a bug I had in my initial interpreter implementation in
Binaryen.