### PR TITLE
New element section encoding in the interpreter

### DIFF
--- a/document/core/syntax/modules.rst
+++ b/document/core/syntax/modules.rst
@@ -261,7 +261,7 @@ The |MELEM| component of a module defines a vector of element segments. Each act
 .. math::
    \begin{array}{llll}
    \production{element segment} & \elem &::=&
-     \{ \ETABLE~\tableidx, \EOFFSET~\expr, \EINIT~\vec(\elemexpr) \} \\&&|&
+     \{ \ETABLE~\tableidx, \EOFFSET~\expr, \ETYPE~\elemtype, \EINIT~\vec(\elemexpr) \} \\&&|&
      \{ \ETYPE~\elemtype, \EINIT~\vec(\elemexpr) \} \\
    \production{elemexpr} & \elemexpr &::=&
      \REFNULL~\END \\&&|&

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -484,15 +484,15 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
    \begin{array}{llclll}
    \production{element segment} & \Telem_I &::=&
      \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
+       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
+       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
+       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{\EINIT~y^\ast \} \\ &&|&
+       \Rightarrow\quad \{\ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{\ETYPE~et,\EINIT~y^\ast \} \\
    \production{offset}  & \Toffset_I &::=&

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -493,20 +493,13 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
 .. math::
    \begin{array}{llclll}
    \production{element segment} & \Telem_I &::=&
-     \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~\{et, init\}{:}\Tfunclist_I~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~et, \EINIT~init \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~\{et, init\}{:}\Tfunclist_I~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~init \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~\{et, init\}{:}\Tfunclist_I~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{\ETYPE~et,\EINIT~init \} \\
-   \production{offset}  & \Toffset_I &::=&
-     \text{(}~\text{offset}~~e{:}\Texpr_I~\text{)} \qquad\Rightarrow\quad \EOFFSET~e \\ &&|&
-     e{:}\Texpr_I \qquad\Rightarrow\quad \EOFFSET~e \\
-   \production{funclist}  & \Tfunclist_I &::=&
-     \text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I) \qquad\Rightarrow\quad \{ \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
-     et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I) \qquad\Rightarrow\quad \{ \ETYPE~et, \EINIT~y^\ast \} \\
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~(et, y^\ast){:}\Telemlist~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~y^\ast \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~(et, y^\ast){:}\Telemlist~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{\ETYPE~et,\EINIT~y^\ast \} \\
+   \production{elemlist}  & \Telemlist &::=&
+     \text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I) \qquad\Rightarrow\quad ( \ETYPE~\FUNCREF, \EINIT~y^\ast ) \\ &&|&
+     et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I) \qquad\Rightarrow\quad ( \ETYPE~et, \EINIT~y^\ast ) \\
    \end{array}
 
 .. note::
@@ -526,14 +519,14 @@ As an abbreviation, a single instruction may occur in place of the offset:
      \text{(}~\text{offset}~~\Tinstr~\text{)}
    \end{array}
 
-Also, the table index can be omitted, defaulting to :math:`\T{0}`.
+Also, the table index can be omitted, defaulting to :math:`\T{0}`. If the table index is omitted, also the :math:`\text{func}` keyword can be omitted.
 
 .. math::
    \begin{array}{llclll}
    \production{element segment} &
     \text{(}~\text{elem}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
        &\equiv&
-     \text{(}~\text{elem}~~0~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
+     \text{(}~\text{elem}~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
    \end{array}
 
 As another abbreviation, element segments may also be specified inline with :ref:`table <text-table>` definitions; see the respective section.

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -293,6 +293,16 @@ An :ref:`element segment <text-elem>` can be given inline with a table definitio
        (\iff \Tid' = \Tid^? \neq \epsilon \vee \Tid' \idfresh) \\
    \end{array}
 
+.. math::
+   \begin{array}{llclll}
+   \production{module field} &
+     \text{(}~\text{table}~~\Tid^?~~\Telemtype~~\text{(}~\text{elem}~~x^n{:}\Tvec(\Texpr)~\text{)}~~\text{)} \quad\equiv \\ & \qquad
+       \text{(}~\text{table}~~\Tid'~~n~~n~~\Telemtype~\text{)}~~
+       \text{(}~\text{elem}~~\Tid'~~\text{(}~\text{i32.const}~~\text{0}~\text{)}~~\Tvec(\Texpr)~\text{)}
+       \\ & \qquad\qquad
+       (\iff \Tid' = \Tid^? \neq \epsilon \vee \Tid' \idfresh) \\
+   \end{array}
+
 Tables can be defined as :ref:`imports <text-import>` or :ref:`exports <text-export>` inline:
 
 .. math::
@@ -485,19 +495,18 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
    \production{element segment} & \Telem_I &::=&
      \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{\ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{\ETYPE~et,\EINIT~y^\ast \} \\
+     \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~\{et, init\}{:}\Tfunclist_I~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \ETYPE~et, \EINIT~init \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~\{et, init\}{:}\Tfunclist_I~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~init \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~\{et, init\}{:}\Tfunclist_I~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{\ETYPE~et,\EINIT~init \} \\
    \production{offset}  & \Toffset_I &::=&
      \text{(}~\text{offset}~~e{:}\Texpr_I~\text{)} \qquad\Rightarrow\quad \EOFFSET~e \\ &&|&
      e{:}\Texpr_I \qquad\Rightarrow\quad \EOFFSET~e \\
+   \production{funclist}  & \Tfunclist_I &::=&
+     \text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I) \qquad\Rightarrow\quad \{ \ETYPE~\FUNCREF, \EINIT~y^\ast \} \\ &&|&
+     et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I) \qquad\Rightarrow\quad \{ \ETYPE~et, \EINIT~y^\ast \} \\
    \end{array}
 
 .. note::

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -483,10 +483,21 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
 .. math::
    \begin{array}{llclll}
    \production{element segment} & \Telem_I &::=&
-     \text{(}~\text{elem}~~\Tid^?~~x{:}\Ttableidx_I~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
+     \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~x{:}\Ttableidx_I~~e{:}\Toffset_I~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETYPE~et, \EINIT~y^\ast \} \\
+     \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~x{:}\Ttableidx_I~~e{:}\Toffset_I~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~y^\ast \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{\EINIT~y^\ast \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{\ETYPE~et,\EINIT~y^\ast \} \\
+   \production{offset}  & \Toffset_I &::=&
+     \text{(}~\text{offset}~~e{:}\Texpr_I~\text{)} \qquad\Rightarrow\quad \EOFFSET~e \\ &&|&
+     e{:}\Texpr_I \qquad\Rightarrow\quad \EOFFSET~e \\
    \end{array}
 
 .. note::

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -485,11 +485,11 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
    \production{element segment} & \Telem_I &::=&
      \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~x{:}\Ttableidx_I~~e{:}\Toffset_I~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~e{:}\Toffset_I~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~0, \EOFFSET~e, \EINIT~y^\ast \} \\ &&|&
-     \text{(}~\text{elem}~~\Tid^?~~x{:}\Ttableidx_I~~e{:}\Toffset_I~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~e{:}\Toffset_I~~et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~\text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I)~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{\EINIT~y^\ast \} \\ &&|&

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -704,7 +704,6 @@
 .. |Toffset| mathdef:: \xref{text/instructions}{text-memarg}{\T{offset}}
 .. |Tfunclist| mathdef:: \xref{text/instructions}{text-memarg}{\T{funclist}}
 
-
 .. |Tlabel| mathdef:: \xref{text/instructions}{text-label}{\T{label}}
 .. |Tinstr| mathdef:: \xref{text/instructions}{text-instr}{\T{instr}}
 .. |Tplaininstr| mathdef:: \xref{text/instructions}{text-plaininstr}{\T{plaininstr}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -702,7 +702,7 @@
 .. |Tmemarg| mathdef:: \xref{text/instructions}{text-memarg}{\T{memarg}}
 .. |Talign| mathdef:: \xref{text/instructions}{text-memarg}{\T{align}}
 .. |Toffset| mathdef:: \xref{text/instructions}{text-memarg}{\T{offset}}
-.. |Tfunclist| mathdef:: \xref{text/instructions}{text-memarg}{\T{funclist}}
+.. |Telemlist| mathdef:: \xref{text/instructions}{text-memarg}{\T{elemlist}}
 
 .. |Tlabel| mathdef:: \xref{text/instructions}{text-label}{\T{label}}
 .. |Tinstr| mathdef:: \xref{text/instructions}{text-instr}{\T{instr}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -702,6 +702,8 @@
 .. |Tmemarg| mathdef:: \xref{text/instructions}{text-memarg}{\T{memarg}}
 .. |Talign| mathdef:: \xref{text/instructions}{text-memarg}{\T{align}}
 .. |Toffset| mathdef:: \xref{text/instructions}{text-memarg}{\T{offset}}
+.. |Tfunclist| mathdef:: \xref{text/instructions}{text-memarg}{\T{funclist}}
+
 
 .. |Tlabel| mathdef:: \xref{text/instructions}{text-label}{\T{label}}
 .. |Tinstr| mathdef:: \xref{text/instructions}{text-instr}{\T{instr}}

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -147,7 +147,7 @@ Element Segments
 
 Element segments :math:`\elem` are classified by :ref:`segment types <syntax-segtype>`.
 
-:math:`\{ \ETABLE~x, \EOFFSET~\expr, \EINIT~e^\ast \}`
+:math:`\{ \ETABLE~x, \EOFFSET~\expr, \ETYPE~et, \EINIT~e^\ast \}`
 ......................................................
 
 * The table :math:`C.\CTABLES[x]` must be defined in the context.
@@ -159,6 +159,8 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
 * The expression :math:`\expr` must be :ref:`valid <valid-expr>` with :ref:`result type <syntax-resulttype>` :math:`[\I32]`.
 
 * The expression :math:`\expr` must be :ref:`constant <valid-constant>`.
+
+* The :ref:`element type <syntax-elemtype>` :math:`et` must be |FUNCREF|.
 
 * For each :math:`e_i` in :math:`e^\ast`,
 
@@ -175,14 +177,18 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
      \qquad
      C \vdashexprconst \expr \const
      \qquad
+     C \vdashexprconst et = \FUNCREF
+     \qquad
      (C \vdashelemexpr e \ok)^\ast
    }{
-     C \vdashelem \{ \ETABLE~x, \EOFFSET~\expr, \EINIT~e^\ast \} : \SACTIVE
+     C \vdashelem \{ \ETABLE~x, \EOFFSET~\expr, \ETYPE~et, \EINIT~e^\ast \} : \SACTIVE
    }
 
 
 :math:`\{ \ETYPE~et, \EINIT~e^\ast \}`
 ......................................
+
+* The :ref:`element type <syntax-elemtype>` :math:`et` must be |FUNCREF|.
 
 * For each :math:`e_i` in :math:`e^\ast`,
 
@@ -193,6 +199,8 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
 
 .. math::
    \frac{
+     C \vdashexprconst et = \FUNCREF
+     \qquad
      (C \vdashelemexpr e \ok)^\ast
    }{
      C \vdashelem \{ \ETYPE~et, \EINIT~e^\ast \} : \SPASSIVE

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -148,7 +148,7 @@ Element Segments
 Element segments :math:`\elem` are classified by :ref:`segment types <syntax-segtype>`.
 
 :math:`\{ \ETABLE~x, \EOFFSET~\expr, \ETYPE~et, \EINIT~e^\ast \}`
-......................................................
+.................................................................
 
 * The table :math:`C.\CTABLES[x]` must be defined in the context.
 
@@ -177,7 +177,7 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
      \qquad
      C \vdashexprconst \expr \const
      \qquad
-     C \vdashexprconst et = \FUNCREF
+     et = \FUNCREF
      \qquad
      (C \vdashelemexpr e \ok)^\ast
    }{
@@ -199,7 +199,7 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
 
 .. math::
    \frac{
-     C \vdashexprconst et = \FUNCREF
+     et = \FUNCREF
      \qquad
      (C \vdashelemexpr e \ok)^\ast
    }{

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -642,23 +642,23 @@ let table_segment s =
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = elem_indices s in
-    ActiveWithIndices {index; offset; init}
+    EActive {index; offset; etype = FuncRefType; init}
   | 1l ->
     let _ = extern_kind s in
     let data = elem_indices s in
-    PassiveWithIndices {data}
+    PassiveWithRefs {etype = FuncRefType; data}
   | 2l ->
     let index = at var s in
     let offset = const s in
     let _ = extern_kind s in
     let init = elem_indices s in
-    ActiveWithIndices {index; offset; init}
+    EActive {index; offset; etype = FuncRefType; init}
   | 4l ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let etype = elem_type s in
     let init = elem_refs s in
-    ActiveWithRefs {index; offset; etype; init}
+    EActive {index; offset; etype; init}
   | 5l ->
     let etype = elem_type s in
     let data = elem_refs s in
@@ -668,7 +668,7 @@ let table_segment s =
     let offset = const s in
     let etype = elem_type s in
     let init = elem_refs s in
-    ActiveWithRefs {index; offset; etype; init}
+    EActive {index; offset; etype; init}
   | _ -> error s (pos s - 1) "invalid table segment kind"
 
 let elem_section s =

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -146,6 +146,11 @@ let elem_type s =
   | -0x10 -> FuncRefType
   | _ -> error s (pos s - 1) "invalid element type"
 
+let extern_kind s =
+  match vs7 s with
+  | 0x00 -> FuncKind
+  | _ -> error s (pos s - 1) "invalid extern kind"
+
 let stack_type s =
   match peek s with
   | Some 0x40 -> skip 1 s; []
@@ -613,27 +618,10 @@ let code_section s =
 
 (* Element section *)
 
-let segment active passive s =
-  match vu32 s with
-  | 0l ->
-    let index = Source.(0l @@ Source.no_region) in
-    let offset = const s in
-    let init = active s in
-    Active {index; offset; init}
-  | 1l ->
-    let etype, data = passive s in
-    Passive {etype; data}
-  | 2l ->
-    let index = at var s in
-    let offset = const s in
-    let init = active s in
-    Active {index; offset; init}
-  | _ -> error s (pos s - 1) "invalid segment kind"
-
-let active_elem s =
+let func_index s =
   ref_func (at var s)
 
-let passive_elem s =
+let elem_expr s =
   match u8 s with
   | 0xd0 -> end_ s; ref_null
   | 0xd2 ->
@@ -642,16 +630,46 @@ let passive_elem s =
     ref_func x
   | _ -> error s (pos s - 1) "invalid elem"
 
-let active_elem_segment s =
-  vec (at active_elem) s
+let elem_indices s =
+  vec (at func_index) s
 
-let passive_elem_segment s =
-  let etype = elem_type s in
-  let init = vec (at passive_elem) s in
-  etype, init
+let elem_refs s =
+  vec (at elem_expr) s
 
 let table_segment s =
-  segment active_elem_segment passive_elem_segment s
+  match vu32 s with
+  | 0l ->
+    let index = Source.(0l @@ Source.no_region) in
+    let offset = const s in
+    let init = elem_indices s in
+    ActiveIndices {index; offset; init}
+  | 1l ->
+    let _ = extern_kind s in
+    let data = elem_indices s in
+    PassiveIndices {data}
+  | 2l ->
+    let index = at var s in
+    let offset = const s in
+    let _ = extern_kind s in
+    let init = elem_indices s in
+    ActiveIndices {index; offset; init}
+  | 4l ->
+    let index = Source.(0l @@ Source.no_region) in
+    let offset = const s in
+    let etype = elem_type s in
+    let init = elem_refs s in
+    ActiveRefs {index; offset; etype; init}
+  | 5l ->
+    let etype = elem_type s in
+    let data = elem_refs s in
+    PassiveRefs {etype; data}
+  | 6l ->
+    let index = at var s in
+    let offset = const s in
+    let etype = elem_type s in
+    let init = elem_refs s in
+    ActiveRefs {index; offset; etype; init}
+  | _ -> error s (pos s - 1) "invalid table segment kind"
 
 let elem_section s =
   section `ElemSection (vec (at table_segment)) [] s
@@ -660,7 +678,21 @@ let elem_section s =
 (* Data section *)
 
 let memory_segment s =
-  segment string (fun s -> (), string s) s
+  match vu32 s with
+  | 0l ->
+    let index = Source.(0l @@ Source.no_region) in
+    let offset = const s in
+    let init = string s in
+    Active {index; offset; init}
+  | 1l ->
+    let data = string s in
+    Passive {data}
+  | 2l ->
+    let index = at var s in
+    let offset = const s in
+    let init = string s in
+    Active {index; offset; init}
+  | _ -> error s (pos s - 1) "invalid memory segment kind"
 
 let data_section s =
   section `DataSection (vec (at memory_segment)) [] s

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -148,7 +148,7 @@ let elem_type s =
 
 let extern_kind s =
   match vs7 s with
-  | 0x00 -> FuncKind
+  | 0x00 -> FuncRefType
   | _ -> error s (pos s - 1) "invalid extern kind"
 
 let stack_type s =
@@ -644,21 +644,20 @@ let table_segment s =
     let init = elem_indices s in
     EActive {index; offset; etype = FuncRefType; init}
   | 1l ->
-    let _ = extern_kind s in
+    let etype = extern_kind s in
     let data = elem_indices s in
-    PassiveWithRefs {etype = FuncRefType; data}
+    PassiveWithRefs {etype; data}
   | 2l ->
     let index = at var s in
     let offset = const s in
-    let _ = extern_kind s in
+    let etype = extern_kind s in
     let init = elem_indices s in
-    EActive {index; offset; etype = FuncRefType; init}
+    EActive {index; offset; etype; init}
   | 4l ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
-    let etype = elem_type s in
     let init = elem_refs s in
-    EActive {index; offset; etype; init}
+    EActive {index; offset; etype = FuncRefType; init}
   | 5l ->
     let etype = elem_type s in
     let data = elem_refs s in

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -642,33 +642,33 @@ let table_segment s =
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = elem_indices s in
-    ActiveIndices {index; offset; init}
+    ActiveWithIndices {index; offset; init}
   | 1l ->
     let _ = extern_kind s in
     let data = elem_indices s in
-    PassiveIndices {data}
+    PassiveWithIndices {data}
   | 2l ->
     let index = at var s in
     let offset = const s in
     let _ = extern_kind s in
     let init = elem_indices s in
-    ActiveIndices {index; offset; init}
+    ActiveWithIndices {index; offset; init}
   | 4l ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let etype = elem_type s in
     let init = elem_refs s in
-    ActiveRefs {index; offset; etype; init}
+    ActiveWithRefs {index; offset; etype; init}
   | 5l ->
     let etype = elem_type s in
     let data = elem_refs s in
-    PassiveRefs {etype; data}
+    PassiveWithRefs {etype; data}
   | 6l ->
     let index = at var s in
     let offset = const s in
     let etype = elem_type s in
     let init = elem_refs s in
-    ActiveRefs {index; offset; etype; init}
+    ActiveWithRefs {index; offset; etype; init}
   | _ -> error s (pos s - 1) "invalid table segment kind"
 
 let elem_section s =

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -642,32 +642,32 @@ let table_segment s =
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = elem_indices s in
-    EActive {index; offset; etype = FuncRefType; init}
+    ElemActive {index; offset; etype = FuncRefType; init}
   | 1l ->
     let etype = extern_kind s in
     let data = elem_indices s in
-    PassiveWithRefs {etype; data}
+    ElemPassive {etype; data}
   | 2l ->
     let index = at var s in
     let offset = const s in
     let etype = extern_kind s in
     let init = elem_indices s in
-    EActive {index; offset; etype; init}
+    ElemActive {index; offset; etype; init}
   | 4l ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = elem_refs s in
-    EActive {index; offset; etype = FuncRefType; init}
+    ElemActive {index; offset; etype = FuncRefType; init}
   | 5l ->
     let etype = elem_type s in
     let data = elem_refs s in
-    PassiveWithRefs {etype; data}
+    ElemPassive {etype; data}
   | 6l ->
     let index = at var s in
     let offset = const s in
     let etype = elem_type s in
     let init = elem_refs s in
-    EActive {index; offset; etype; init}
+    ElemActive {index; offset; etype; init}
   | _ -> error s (pos s - 1) "invalid table segment kind"
 
 let elem_section s =
@@ -682,15 +682,15 @@ let memory_segment s =
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = string s in
-    Active {index; offset; init}
+    DataActive {index; offset; init}
   | 1l ->
     let data = string s in
-    Passive {data}
+    DataPassive {data}
   | 2l ->
     let index = at var s in
     let offset = const s in
     let init = string s in
-    Active {index; offset; init}
+    DataActive {index; offset; init}
   | _ -> error s (pos s - 1) "invalid memory segment kind"
 
 let data_section s =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -489,22 +489,24 @@ let encode m =
 
     let elem_indices data = vec elem_index data
 
+    let all_func_ref l = not (List.exists (fun elem -> elem.it = RefNull) l)
+
     let table_segment seg =
       match seg.it with
-      | ElemActive {index = {it = 0l;_}; offset; init; _}
-        when not (contains_null_ref init) ->
+      | ActiveElem {index = {it = 0l;_}; offset; init; _}
+        when all_func_ref init ->
         u8 0x00; const offset; elem_indices init
-      | ElemPassive {data; _}
-        when not (contains_null_ref data) ->
+      | PassiveElem {data; _}
+        when all_func_ref data ->
         u8 0x01; u8 0x00; elem_indices data
-      | ElemActive {index; offset; init; _}
-        when not (contains_null_ref init) ->
+      | ActiveElem {index; offset; init; _}
+        when all_func_ref init ->
         u8 0x02; var index; const offset; u8 0x00; elem_indices init
-      | ElemActive {index = {it = 0l;_}; offset; etype; init} ->
+      | ActiveElem {index = {it = 0l;_}; offset; etype; init} ->
         u8 0x04; const offset; vec elem_expr init
-      | ElemPassive {etype; data} ->
+      | PassiveElem {etype; data} ->
         u8 0x05; elem_type etype; vec elem_expr data
-      | ElemActive {index; offset; etype; init} ->
+      | ActiveElem {index; offset; etype; init} ->
         u8 0x06; var index; const offset; elem_type etype; vec elem_expr init
 
     let elem_section elems =
@@ -513,12 +515,12 @@ let encode m =
     (* Data section *)
     let memory_segment seg =
       match seg.it with
-      | DataActive {index = {it = 0l;_}; offset; init} ->
-          u8 0x00; const offset; string init
-      | DataPassive {data} ->
-          u8 0x01; string data
-      | DataActive {index; offset; init} ->
-          u8 0x02; var index; const offset; string init
+      | ActiveData {index = {it = 0l;_}; offset; init} ->
+        u8 0x00; const offset; string init
+      | PassiveData {data} ->
+        u8 0x01; string data
+      | ActiveData {index; offset; init} ->
+        u8 0x02; var index; const offset; string init
 
     let data_section datas =
       section 11 (vec memory_segment) datas (datas <> [])

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -487,21 +487,24 @@ let encode m =
       | RefNull -> assert false
       | RefFunc x -> var x
 
-    let elem_indices init = vec elem_index init
+    let elem_indices data = vec elem_index data
 
     let table_segment seg =
       match seg.it with
-      | ActiveWithIndices {index = {it = 0l;_}; offset; init} ->
+      | EActive {index = {it = 0l;_}; offset; init; _}
+        when not (contains_null_ref init) ->
         u8 0x00; const offset; elem_indices init
-      | PassiveWithIndices {data} ->
+      | PassiveWithRefs {data; _}
+        when not (contains_null_ref data) ->
         u8 0x01; u8 0x00; elem_indices data
-      | ActiveWithIndices {index; offset; init} ->
+      | EActive {index; offset; init; _}
+        when not (contains_null_ref init) ->
         u8 0x02; var index; const offset; u8 0x00; elem_indices init
-      | ActiveWithRefs {index = {it = 0l;_}; offset; etype; init} ->
+      | EActive {index = {it = 0l;_}; offset; etype; init} ->
         u8 0x04; const offset; elem_type etype; vec elem_expr init
       | PassiveWithRefs {etype; data} ->
         u8 0x05; elem_type etype; vec elem_expr data
-      | ActiveWithRefs {index; offset; etype; init} ->
+      | EActive {index; offset; etype; init} ->
         u8 0x06; var index; const offset; elem_type etype; vec elem_expr init
 
     let elem_section elems =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -491,17 +491,17 @@ let encode m =
 
     let table_segment seg =
       match seg.it with
-      | ActiveIndices {index = {it = 0l;_}; offset; init} ->
+      | ActiveWithIndices {index = {it = 0l;_}; offset; init} ->
         u8 0x00; const offset; elem_indices init
-      | PassiveIndices {data} ->
+      | PassiveWithIndices {data} ->
         u8 0x01; u8 0x00; elem_indices data
-      | ActiveIndices {index; offset; init} ->
+      | ActiveWithIndices {index; offset; init} ->
         u8 0x02; var index; const offset; u8 0x00; elem_indices init
-      | ActiveRefs {index = {it = 0l;_}; offset; etype; init} ->
+      | ActiveWithRefs {index = {it = 0l;_}; offset; etype; init} ->
         u8 0x04; const offset; elem_type etype; vec elem_expr init
-      | PassiveRefs {etype; data} ->
+      | PassiveWithRefs {etype; data} ->
         u8 0x05; elem_type etype; vec elem_expr data
-      | ActiveRefs {index; offset; etype; init} ->
+      | ActiveWithRefs {index; offset; etype; init} ->
         u8 0x06; var index; const offset; elem_type etype; vec elem_expr init
 
     let elem_section elems =

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -501,7 +501,7 @@ let encode m =
         when not (contains_null_ref init) ->
         u8 0x02; var index; const offset; u8 0x00; elem_indices init
       | EActive {index = {it = 0l;_}; offset; etype; init} ->
-        u8 0x04; const offset; elem_type etype; vec elem_expr init
+        u8 0x04; const offset; vec elem_expr init
       | PassiveWithRefs {etype; data} ->
         u8 0x05; elem_type etype; vec elem_expr data
       | EActive {index; offset; etype; init} ->

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -477,39 +477,45 @@ let encode m =
       section 10 (vec code) fs (fs <> [])
 
     (* Element section *)
-    let segment active passive seg =
-      match seg.it with
-      | Active {index; offset; init} ->
-        if index.it = 0l then
-          u8 0x00
-        else begin
-          u8 0x02; var index
-        end;
-        const offset; active init
-      | Passive {etype; data} ->
-        u8 0x01; passive etype data
-
-    let active_elem el =
-      match el.it with
-      | RefNull -> assert false
-      | RefFunc x -> var x
-
-    let passive_elem el =
+    let elem_expr el =
       match el.it with
       | RefNull -> u8 0xd0; end_ ()
       | RefFunc x -> u8 0xd2; var x; end_ ()
 
+    let elem_index el =
+      match el.it with
+      | RefNull -> assert false
+      | RefFunc x -> var x
+
+    let elem_indices init = vec elem_index init
+
     let table_segment seg =
-      let active init = vec active_elem init in
-      let passive etype data = elem_type etype; vec passive_elem data in
-      segment active passive seg
+      match seg.it with
+      | ActiveIndices {index = {it = 0l;_}; offset; init} ->
+        u8 0x00; const offset; elem_indices init
+      | PassiveIndices {data} ->
+        u8 0x01; u8 0x00; elem_indices data
+      | ActiveIndices {index; offset; init} ->
+        u8 0x02; var index; const offset; u8 0x00; elem_indices init
+      | ActiveRefs {index = {it = 0l;_}; offset; etype; init} ->
+        u8 0x04; const offset; elem_type etype; vec elem_expr init
+      | PassiveRefs {etype; data} ->
+        u8 0x05; elem_type etype; vec elem_expr data
+      | ActiveRefs {index; offset; etype; init} ->
+        u8 0x06; var index; const offset; elem_type etype; vec elem_expr init
 
     let elem_section elems =
       section 9 (vec table_segment) elems (elems <> [])
 
     (* Data section *)
     let memory_segment seg =
-      segment string (fun _ s -> string s) seg
+      match seg.it with
+      | Active {index = {it = 0l;_}; offset; init} ->
+          u8 0x00; const offset; string init
+      | Passive {data} ->
+          u8 0x01; string data
+      | Active {index; offset; init} ->
+          u8 0x02; var index; const offset; string init
 
     let data_section datas =
       section 11 (vec memory_segment) datas (datas <> [])

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -491,20 +491,20 @@ let encode m =
 
     let table_segment seg =
       match seg.it with
-      | EActive {index = {it = 0l;_}; offset; init; _}
+      | ElemActive {index = {it = 0l;_}; offset; init; _}
         when not (contains_null_ref init) ->
         u8 0x00; const offset; elem_indices init
-      | PassiveWithRefs {data; _}
+      | ElemPassive {data; _}
         when not (contains_null_ref data) ->
         u8 0x01; u8 0x00; elem_indices data
-      | EActive {index; offset; init; _}
+      | ElemActive {index; offset; init; _}
         when not (contains_null_ref init) ->
         u8 0x02; var index; const offset; u8 0x00; elem_indices init
-      | EActive {index = {it = 0l;_}; offset; etype; init} ->
+      | ElemActive {index = {it = 0l;_}; offset; etype; init} ->
         u8 0x04; const offset; vec elem_expr init
-      | PassiveWithRefs {etype; data} ->
+      | ElemPassive {etype; data} ->
         u8 0x05; elem_type etype; vec elem_expr data
-      | EActive {index; offset; etype; init} ->
+      | ElemActive {index; offset; etype; init} ->
         u8 0x06; var index; const offset; elem_type etype; vec elem_expr init
 
     let elem_section elems =
@@ -513,11 +513,11 @@ let encode m =
     (* Data section *)
     let memory_segment seg =
       match seg.it with
-      | Active {index = {it = 0l;_}; offset; init} ->
+      | DataActive {index = {it = 0l;_}; offset; init} ->
           u8 0x00; const offset; string init
-      | Passive {data} ->
+      | DataPassive {data} ->
           u8 0x01; string data
-      | Active {index; offset; init} ->
+      | DataActive {index; offset; init} ->
           u8 0x02; var index; const offset; string init
 
     let data_section datas =

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -448,9 +448,7 @@ let elem_list inst init =
 
 let create_elem (inst : module_inst) (seg : table_segment) : elem_inst =
   match seg.it with
-  | ActiveWithIndices _ -> ref None
-  | ActiveWithRefs _ -> ref None
-  | PassiveWithIndices {data} -> ref (Some (elem_list inst data))
+  | EActive _ -> ref None
   | PassiveWithRefs {data; _} -> ref (Some (elem_list inst data))
 
 let create_data (inst : module_inst) (seg : memory_segment) : data_inst =
@@ -466,15 +464,13 @@ let init_func (inst : module_inst) (func : func_inst) =
 
 let init_table (inst : module_inst) (seg : table_segment) =
   match seg.it with
-  | ActiveWithIndices {index; offset = const; init}
-  | ActiveWithRefs {index; offset = const; init; _} ->
+  | EActive {index; offset = const; init; _} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
     let elems = elem_list inst init in
     let len = Int32.of_int (List.length elems) in
     (try Table.init tab elems offset 0l len
     with Table.Bounds -> Link.error seg.at "elements segment does not fit table")
-  | PassiveWithIndices _
   | PassiveWithRefs _ -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -448,10 +448,10 @@ let elem_list inst init =
 
 let create_elem (inst : module_inst) (seg : table_segment) : elem_inst =
   match seg.it with
-  | ActiveIndices _ -> ref None
-  | ActiveRefs _ -> ref None
-  | PassiveIndices {data} -> ref (Some (elem_list inst data))
-  | PassiveRefs {data; _} -> ref (Some (elem_list inst data))
+  | ActiveWithIndices _ -> ref None
+  | ActiveWithRefs _ -> ref None
+  | PassiveWithIndices {data} -> ref (Some (elem_list inst data))
+  | PassiveWithRefs {data; _} -> ref (Some (elem_list inst data))
 
 let create_data (inst : module_inst) (seg : memory_segment) : data_inst =
   match seg.it with
@@ -466,16 +466,16 @@ let init_func (inst : module_inst) (func : func_inst) =
 
 let init_table (inst : module_inst) (seg : table_segment) =
   match seg.it with
-  | ActiveIndices {index; offset = const; init}
-  | ActiveRefs {index; offset = const; init; _} ->
+  | ActiveWithIndices {index; offset = const; init}
+  | ActiveWithRefs {index; offset = const; init; _} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
     let elems = elem_list inst init in
     let len = Int32.of_int (List.length elems) in
     (try Table.init tab elems offset 0l len
     with Table.Bounds -> Link.error seg.at "elements segment does not fit table")
-  | PassiveIndices _
-  | PassiveRefs _ -> ()
+  | PassiveWithIndices _
+  | PassiveWithRefs _ -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =
   match seg.it with

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -448,13 +448,15 @@ let elem_list inst init =
 
 let create_elem (inst : module_inst) (seg : table_segment) : elem_inst =
   match seg.it with
-  | Active _ -> ref None
-  | Passive {data; _} -> ref (Some (elem_list inst data))
+  | ActiveIndices _ -> ref None
+  | ActiveRefs _ -> ref None
+  | PassiveIndices {data} -> ref (Some (elem_list inst data))
+  | PassiveRefs {data; _} -> ref (Some (elem_list inst data))
 
 let create_data (inst : module_inst) (seg : memory_segment) : data_inst =
   match seg.it with
   | Active _ -> ref None
-  | Passive {data; _} -> ref (Some data)
+  | Passive {data} -> ref (Some data)
 
 
 let init_func (inst : module_inst) (func : func_inst) =
@@ -464,14 +466,16 @@ let init_func (inst : module_inst) (func : func_inst) =
 
 let init_table (inst : module_inst) (seg : table_segment) =
   match seg.it with
-  | Active {index; offset = const; init} ->
+  | ActiveIndices {index; offset = const; init}
+  | ActiveRefs {index; offset = const; init; _} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
     let elems = elem_list inst init in
     let len = Int32.of_int (List.length elems) in
     (try Table.init tab elems offset 0l len
     with Table.Bounds -> Link.error seg.at "elements segment does not fit table")
-  | Passive _ -> ()
+  | PassiveIndices _
+  | PassiveRefs _ -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =
   match seg.it with

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -448,13 +448,13 @@ let elem_list inst init =
 
 let create_elem (inst : module_inst) (seg : table_segment) : elem_inst =
   match seg.it with
-  | ElemActive _ -> ref None
-  | ElemPassive {data; _} -> ref (Some (elem_list inst data))
+  | ActiveElem _ -> ref None
+  | PassiveElem {data; _} -> ref (Some (elem_list inst data))
 
 let create_data (inst : module_inst) (seg : memory_segment) : data_inst =
   match seg.it with
-  | DataActive _ -> ref None
-  | DataPassive {data} -> ref (Some data)
+  | ActiveData _ -> ref None
+  | PassiveData {data} -> ref (Some data)
 
 
 let init_func (inst : module_inst) (func : func_inst) =
@@ -464,25 +464,25 @@ let init_func (inst : module_inst) (func : func_inst) =
 
 let init_table (inst : module_inst) (seg : table_segment) =
   match seg.it with
-  | ElemActive {index; offset = const; init; _} ->
+  | ActiveElem {index; offset = const; init; _} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
     let elems = elem_list inst init in
     let len = Int32.of_int (List.length elems) in
     (try Table.init tab elems offset 0l len
     with Table.Bounds -> Link.error seg.at "elements segment does not fit table")
-  | ElemPassive _ -> ()
+  | PassiveElem _ -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =
   match seg.it with
-  | DataActive {index; offset = const; init} ->
+  | ActiveData {index; offset = const; init} ->
     let mem = memory inst index in
     let offset' = i32 (eval_const inst const) const.at in
     let offset = I64_convert.extend_i32_u offset' in
     let len = Int32.of_int (String.length init) in
     (try Memory.init mem init offset 0L len
     with Memory.Bounds -> Link.error seg.at "data segment does not fit memory")
-  | DataPassive _ -> ()
+  | PassiveData _ -> ()
 
 
 let add_import (m : module_) (ext : extern) (im : import) (inst : module_inst)

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -448,13 +448,13 @@ let elem_list inst init =
 
 let create_elem (inst : module_inst) (seg : table_segment) : elem_inst =
   match seg.it with
-  | EActive _ -> ref None
-  | PassiveWithRefs {data; _} -> ref (Some (elem_list inst data))
+  | ElemActive _ -> ref None
+  | ElemPassive {data; _} -> ref (Some (elem_list inst data))
 
 let create_data (inst : module_inst) (seg : memory_segment) : data_inst =
   match seg.it with
-  | Active _ -> ref None
-  | Passive {data} -> ref (Some data)
+  | DataActive _ -> ref None
+  | DataPassive {data} -> ref (Some data)
 
 
 let init_func (inst : module_inst) (func : func_inst) =
@@ -464,25 +464,25 @@ let init_func (inst : module_inst) (func : func_inst) =
 
 let init_table (inst : module_inst) (seg : table_segment) =
   match seg.it with
-  | EActive {index; offset = const; init; _} ->
+  | ElemActive {index; offset = const; init; _} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
     let elems = elem_list inst init in
     let len = Int32.of_int (List.length elems) in
     (try Table.init tab elems offset 0l len
     with Table.Bounds -> Link.error seg.at "elements segment does not fit table")
-  | PassiveWithRefs _ -> ()
+  | ElemPassive _ -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =
   match seg.it with
-  | Active {index; offset = const; init} ->
+  | DataActive {index; offset = const; init} ->
     let mem = memory inst index in
     let offset' = i32 (eval_const inst const) const.at in
     let offset = I64_convert.extend_i32_u offset' in
     let len = Int32.of_int (String.length init) in
     (try Memory.init mem init offset 0L len
     with Memory.Bounds -> Link.error seg.at "data segment does not fit memory")
-  | Passive _ -> ()
+  | DataPassive _ -> ()
 
 
 let add_import (m : module_) (ext : extern) (im : import) (inst : module_inst)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -148,13 +148,13 @@ and elem' =
 
 type table_segment = table_segment' Source.phrase
 and table_segment' =
-  | ElemActive of {index : var; offset : const; etype : elem_type; init : elem list}
-  | ElemPassive of {etype : elem_type; data : elem list}
+  | ActiveElem of {index : var; offset : const; etype : elem_type; init : elem list}
+  | PassiveElem of {etype : elem_type; data : elem list}
 
 type memory_segment = memory_segment' Source.phrase
 and memory_segment' =
-  | DataActive of {index : var; offset : const; init : string}
-  | DataPassive of {data : string}
+  | ActiveData of {index : var; offset : const; init : string}
+  | PassiveData of {data : string}
 
 
 (* Modules *)
@@ -267,6 +267,4 @@ let string_of_name n =
   in
   List.iter escape n;
   Buffer.contents b
-
-let contains_null_ref l = List.exists (fun elem -> elem.it = RefNull) l
 

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -148,10 +148,8 @@ and elem' =
 
 type table_segment = table_segment' Source.phrase
 and table_segment' =
-  | ActiveWithRefs of {index : var; offset : const; etype : elem_type; init : elem list}
-  | ActiveWithIndices of {index : var; offset : const; init : elem list}
+  | EActive of {index : var; offset : const; etype : elem_type; init : elem list}
   | PassiveWithRefs of {etype : elem_type; data : elem list}
-  | PassiveWithIndices of {data : elem list}
 
 type memory_segment = memory_segment' Source.phrase
 and memory_segment' =
@@ -269,3 +267,6 @@ let string_of_name n =
   in
   List.iter escape n;
   Buffer.contents b
+
+let contains_null_ref l = List.exists (fun elem -> elem.it = RefNull) l
+

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -148,13 +148,13 @@ and elem' =
 
 type table_segment = table_segment' Source.phrase
 and table_segment' =
-  | EActive of {index : var; offset : const; etype : elem_type; init : elem list}
-  | PassiveWithRefs of {etype : elem_type; data : elem list}
+  | ElemActive of {index : var; offset : const; etype : elem_type; init : elem list}
+  | ElemPassive of {etype : elem_type; data : elem list}
 
 type memory_segment = memory_segment' Source.phrase
 and memory_segment' =
-  | Active of {index : var; offset : const; init : string}
-  | Passive of {data : string}
+  | DataActive of {index : var; offset : const; init : string}
+  | DataPassive of {data : string}
 
 
 (* Modules *)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -140,20 +140,23 @@ and memory' =
   mtype : memory_type;
 }
 
-type ('data, 'ty) segment = ('data, 'ty) segment' Source.phrase
-and ('data, 'ty) segment' =
-  | ActiveRefs of {index : var; offset : const; etype : 'ty; init : 'data}
-  | ActiveIndices of {index : var; offset : const; init : 'data}
-  | PassiveRefs of {etype : 'ty; data : 'data}
-  | PassiveIndices of {data : 'data}
-
 type elem = elem' Source.phrase
 and elem' =
   | RefNull
   | RefFunc of var
 
-type table_segment = (elem list, elem_type) segment
-type memory_segment = (string, unit) segment
+
+type table_segment = table_segment' Source.phrase
+and table_segment' =
+  | ActiveRefs of {index : var; offset : const; etype : elem_type; init : elem list}
+  | ActiveIndices of {index : var; offset : const; init : elem list}
+  | PassiveRefs of {etype : elem_type; data : elem list}
+  | PassiveIndices of {data : elem list}
+
+type memory_segment = memory_segment' Source.phrase
+and memory_segment' =
+  | Active of {index : var; offset : const; init : string}
+  | Passive of {data : string}
 
 
 (* Modules *)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -148,10 +148,10 @@ and elem' =
 
 type table_segment = table_segment' Source.phrase
 and table_segment' =
-  | ActiveRefs of {index : var; offset : const; etype : elem_type; init : elem list}
-  | ActiveIndices of {index : var; offset : const; init : elem list}
-  | PassiveRefs of {etype : elem_type; data : elem list}
-  | PassiveIndices of {data : elem list}
+  | ActiveWithRefs of {index : var; offset : const; etype : elem_type; init : elem list}
+  | ActiveWithIndices of {index : var; offset : const; init : elem list}
+  | PassiveWithRefs of {etype : elem_type; data : elem list}
+  | PassiveWithIndices of {data : elem list}
 
 type memory_segment = memory_segment' Source.phrase
 and memory_segment' =

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -142,8 +142,10 @@ and memory' =
 
 type ('data, 'ty) segment = ('data, 'ty) segment' Source.phrase
 and ('data, 'ty) segment' =
-  | Active of {index : var; offset : const; init : 'data}
-  | Passive of {etype : 'ty; data : 'data}
+  | ActiveRefs of {index : var; offset : const; etype : 'ty; init : 'data}
+  | ActiveIndices of {index : var; offset : const; init : 'data}
+  | PassiveRefs of {etype : 'ty; data : 'data}
+  | PassiveIndices of {data : 'data}
 
 type elem = elem' Source.phrase
 and elem' =

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -97,14 +97,14 @@ let elem (e : elem) =
 
 let table_segment (s : table_segment) =
   match s.it with
-  | ElemActive {index; offset; init; _} ->
+  | ActiveElem {index; offset; init; _} ->
     tables (var index) ++ const offset ++ list elem init
-  | ElemPassive {data; _} -> list elem data
+  | PassiveElem {data; _} -> list elem data
 
 let memory_segment (s : memory_segment) =
   match s.it with
-  | DataActive {index; offset; init} -> memories (var index) ++ const offset
-  | DataPassive {data} -> empty
+  | ActiveData {index; offset; init} -> memories (var index) ++ const offset
+  | PassiveData {data} -> empty
 
 let type_ (t : type_) = empty
 

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -97,10 +97,8 @@ let elem (e : elem) =
 
 let table_segment (s : table_segment) =
   match s.it with
-  | ActiveWithIndices {index; offset; init}
-  | ActiveWithRefs {index; offset; init; _} ->
+  | EActive {index; offset; init; _} ->
     tables (var index) ++ const offset ++ list elem init
-  | PassiveWithIndices {data}
   | PassiveWithRefs {data; _} -> list elem data
 
 let memory_segment (s : memory_segment) =

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -97,11 +97,11 @@ let elem (e : elem) =
 
 let table_segment (s : table_segment) =
   match s.it with
-  | ActiveIndices {index; offset; init}
-  | ActiveRefs {index; offset; init; _} ->
+  | ActiveWithIndices {index; offset; init}
+  | ActiveWithRefs {index; offset; init; _} ->
     tables (var index) ++ const offset ++ list elem init
-  | PassiveIndices {data}
-  | PassiveRefs {data; _} -> list elem data
+  | PassiveWithIndices {data}
+  | PassiveWithRefs {data; _} -> list elem data
 
 let memory_segment (s : memory_segment) =
   match s.it with

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -97,14 +97,16 @@ let elem (e : elem) =
 
 let table_segment (s : table_segment) =
   match s.it with
-  | Active {index; offset; init} ->
+  | ActiveIndices {index; offset; init}
+  | ActiveRefs {index; offset; init; _} ->
     tables (var index) ++ const offset ++ list elem init
-  | Passive {etype; data} -> list elem data
+  | PassiveIndices {data}
+  | PassiveRefs {data; _} -> list elem data
 
 let memory_segment (s : memory_segment) =
   match s.it with
   | Active {index; offset; init} -> memories (var index) ++ const offset
-  | Passive {etype; data} -> empty
+  | Passive {data} -> empty
 
 let type_ (t : type_) = empty
 

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -97,14 +97,14 @@ let elem (e : elem) =
 
 let table_segment (s : table_segment) =
   match s.it with
-  | EActive {index; offset; init; _} ->
+  | ElemActive {index; offset; init; _} ->
     tables (var index) ++ const offset ++ list elem init
-  | PassiveWithRefs {data; _} -> list elem data
+  | ElemPassive {data; _} -> list elem data
 
 let memory_segment (s : memory_segment) =
   match s.it with
-  | Active {index; offset; init} -> memories (var index) ++ const offset
-  | Passive {data} -> empty
+  | DataActive {index; offset; init} -> memories (var index) ++ const offset
+  | DataPassive {data} -> empty
 
 let type_ (t : type_) = empty
 

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -2,6 +2,7 @@
 
 type value_type = I32Type | I64Type | F32Type | F64Type
 type elem_type = FuncRefType
+type extern_kind = FuncKind
 type stack_type = value_type list
 type func_type = FuncType of stack_type * stack_type
 

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -2,7 +2,6 @@
 
 type value_type = I32Type | I64Type | F32Type | F64Type
 type elem_type = FuncRefType
-type extern_kind = FuncKind
 type stack_type = value_type list
 type func_type = FuncType of stack_type * stack_type
 

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -308,15 +308,16 @@ let elem_expr el =
 
 let elems seg =
   match seg.it with
-  | ActiveIndices {index; offset; init} ->
-    Node ("elem", Node ("table", [atom var index]) :: Node ("offset", const offset) :: Atom "func"
-    :: list elem_index init)
-  | PassiveIndices {data} ->
+  | ActiveWithIndices {index; offset; init} ->
+    Node ("elem", Node ("table", [atom var index])
+    :: Node ("offset", const offset) :: Atom "func" :: list elem_index init)
+  | PassiveWithIndices {data} ->
     Node ("elem func", list elem_index data)
-  | ActiveRefs {index; offset; etype; init} ->
-    Node ("elem", Node ("table", [atom var index]) :: Node ("offset", const offset)
+  | ActiveWithRefs {index; offset; etype; init} ->
+    Node ("elem", Node ("table", [atom var index])
+    :: Node ("offset", const offset)
     :: atom elem_type etype :: list elem_expr init)
-  | PassiveRefs {etype; data} -> Node ("elem", atom elem_type etype
+  | PassiveWithRefs {etype; data} -> Node ("elem", atom elem_type etype
     :: list elem_expr data)
 
 let data seg =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -306,34 +306,37 @@ let elem_expr el =
   | RefNull -> Node ("ref.null", [])
   | RefFunc x -> Node ("ref.func", [atom var x])
 
+let all_func_ref l = not (List.exists (fun elem -> elem.it = RefNull) l)
+
 let elems seg =
   match seg.it with
-  | ElemActive {index = {it = 0l;_}; offset; init; _}
-    when not (contains_null_ref init) ->
+  | ActiveElem {index = {it = 0l;_}; offset; init; _}
+    when all_func_ref init ->
     Node ("elem", Node ("offset", const offset) :: list elem_index init)
-  | ElemActive {index; offset; init; _}
-    when not (contains_null_ref init) ->
+  | ActiveElem {index; offset; init; _}
+    when all_func_ref init ->
     Node ("elem", Node ("table", [atom var index])
     :: Node ("offset", const offset) :: Atom "func" :: list elem_index init)
-  | ElemActive {index = {it = 0l;_}; offset; etype; init} ->
+  | ActiveElem {index = {it = 0l;_}; offset; etype; init} ->
     Node ("elem", Node ("offset", const offset) :: atom elem_type etype
     :: list elem_expr init)
-  | ElemActive {index; offset; etype; init} ->
+  | ActiveElem {index; offset; etype; init} ->
     Node ("elem", Node ("table", [atom var index])
     :: Node ("offset", const offset)
     :: atom elem_type etype :: list elem_expr init)
-  | ElemPassive {data; _}
-    when not (contains_null_ref data) ->
+  | PassiveElem {data; _}
+    when all_func_ref data ->
     Node ("elem func", list elem_index data)
-  | ElemPassive {etype; data} -> Node ("elem", atom elem_type etype
+  | PassiveElem {etype; data} ->
+    Node ("elem", atom elem_type etype
     :: list elem_expr data)
 
 let data seg =
   match seg.it with
-  | DataActive {index; offset; init} ->
+  | ActiveData {index; offset; init} ->
     Node ("data", atom var index :: Node ("offset", const offset)
     :: break_bytes init)
-  | DataPassive {data} -> Node ("data", break_bytes data)
+  | PassiveData {data} -> Node ("data", break_bytes data)
 
 
 (* Modules *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -308,32 +308,32 @@ let elem_expr el =
 
 let elems seg =
   match seg.it with
-  | EActive {index = {it = 0l;_}; offset; init; _}
+  | ElemActive {index = {it = 0l;_}; offset; init; _}
     when not (contains_null_ref init) ->
     Node ("elem", Node ("offset", const offset) :: list elem_index init)
-  | EActive {index; offset; init; _}
+  | ElemActive {index; offset; init; _}
     when not (contains_null_ref init) ->
     Node ("elem", Node ("table", [atom var index])
     :: Node ("offset", const offset) :: Atom "func" :: list elem_index init)
-  | EActive {index = {it = 0l;_}; offset; etype; init} ->
-    Node ("elem", Node ("offset", const offset)
-    :: atom elem_type etype :: list elem_expr init)
-  | EActive {index; offset; etype; init} ->
+  | ElemActive {index = {it = 0l;_}; offset; etype; init} ->
+    Node ("elem", Node ("offset", const offset) :: atom elem_type etype
+    :: list elem_expr init)
+  | ElemActive {index; offset; etype; init} ->
     Node ("elem", Node ("table", [atom var index])
     :: Node ("offset", const offset)
     :: atom elem_type etype :: list elem_expr init)
-  | PassiveWithRefs {data; _}
+  | ElemPassive {data; _}
     when not (contains_null_ref data) ->
     Node ("elem func", list elem_index data)
-  | PassiveWithRefs {etype; data} -> Node ("elem", atom elem_type etype
+  | ElemPassive {etype; data} -> Node ("elem", atom elem_type etype
     :: list elem_expr data)
 
 let data seg =
   match seg.it with
-  | Active {index; offset; init} ->
+  | DataActive {index; offset; init} ->
     Node ("data", atom var index :: Node ("offset", const offset)
     :: break_bytes init)
-  | Passive {data} -> Node ("data", break_bytes data)
+  | DataPassive {data} -> Node ("data", break_bytes data)
 
 
 (* Modules *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -296,29 +296,35 @@ let memory off i mem =
   let {mtype = MemoryType lim} = mem.it in
   Node ("memory $" ^ nat (off + i) ^ " " ^ limits nat32 lim, [])
 
-let segment head active passive seg =
-  match seg.it with
-  | Active {index; offset; init} ->
-    Node (head, atom var index :: Node ("offset", const offset) :: active init)
-  | Passive {etype; data} -> Node (head, passive etype data)
-
-let active_elem el =
+let elem_index el =
   match el.it with
   | RefNull -> assert false
   | RefFunc x -> atom var x
 
-let passive_elem el =
+let elem_expr el =
   match el.it with
   | RefNull -> Node ("ref.null", [])
   | RefFunc x -> Node ("ref.func", [atom var x])
 
 let elems seg =
-  let active init = list active_elem init in
-  let passive etype init = atom elem_type etype :: list passive_elem init in
-  segment "elem" active passive seg
+  match seg.it with
+  | ActiveIndices {index; offset; init} ->
+    Node ("elem", Node ("table", [atom var index]) :: Node ("offset", const offset) :: Atom "func"
+    :: list elem_index init)
+  | PassiveIndices {data} ->
+    Node ("elem func", list elem_index data)
+  | ActiveRefs {index; offset; etype; init} ->
+    Node ("elem", Node ("table", [atom var index]) :: Node ("offset", const offset)
+    :: atom elem_type etype :: list elem_expr init)
+  | PassiveRefs {etype; data} -> Node ("elem", atom elem_type etype
+    :: list elem_expr data)
 
 let data seg =
-  segment "data" break_bytes (fun _ bs -> break_bytes bs) seg
+  match seg.it with
+  | Active {index; offset; init} ->
+    Node ("data", atom var index :: Node ("offset", const offset)
+    :: break_bytes init)
+  | Passive {data} -> Node ("data", break_bytes data)
 
 
 (* Modules *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -308,15 +308,23 @@ let elem_expr el =
 
 let elems seg =
   match seg.it with
-  | ActiveWithIndices {index; offset; init} ->
+  | EActive {index = {it = 0l;_}; offset; init; _}
+    when not (contains_null_ref init) ->
+    Node ("elem", Node ("offset", const offset) :: list elem_index init)
+  | EActive {index; offset; init; _}
+    when not (contains_null_ref init) ->
     Node ("elem", Node ("table", [atom var index])
     :: Node ("offset", const offset) :: Atom "func" :: list elem_index init)
-  | PassiveWithIndices {data} ->
-    Node ("elem func", list elem_index data)
-  | ActiveWithRefs {index; offset; etype; init} ->
+  | EActive {index = {it = 0l;_}; offset; etype; init} ->
+    Node ("elem", Node ("offset", const offset)
+    :: atom elem_type etype :: list elem_expr init)
+  | EActive {index; offset; etype; init} ->
     Node ("elem", Node ("table", [atom var index])
     :: Node ("offset", const offset)
     :: atom elem_type etype :: list elem_expr init)
+  | PassiveWithRefs {data; _}
+    when not (contains_null_ref data) ->
+    Node ("elem func", list elem_index data)
   | PassiveWithRefs {etype; data} -> Node ("elem", atom elem_type etype
     :: list elem_expr data)
 

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -594,20 +594,21 @@ elem :
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ActiveWithIndices {index = 0l @@ at; offset = $4 c; init = $5 c func} @@ at }
+        EActive {index = 0l @@ at; offset = $4 c; etype = FuncRefType;
+                           init = $5 c func} @@ at }
   | LPAR ELEM bind_var_opt extern_kind elemindex_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> PassiveWithIndices {data = $5 c func} @@ at }
+      fun () -> PassiveWithRefs {etype = FuncRefType; data = $5 c func} @@ at }
   | LPAR ELEM bind_var_opt table_ref offset extern_kind elemindex_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      ActiveWithIndices {index = $4 c table; offset = $5 c; init = $7 c func} @@ at }
+        EActive {index = $4 c table; offset = $5 c; etype = FuncRefType; init = $7 c func} @@ at }
   | LPAR ELEM bind_var_opt offset elem_type elemref_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> ActiveWithRefs {index = 0l @@ at; offset = $4 c;
+      fun () -> EActive {index = 0l @@ at; offset = $4 c;
                             etype = $5; init = $6 c} @@ at }
   | LPAR ELEM bind_var_opt elem_type elemref_list RPAR
     { let at = at () in
@@ -617,7 +618,7 @@ elem :
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ActiveWithRefs {index = $4 c table; offset = $5 c; etype = $6; init = $7 c} @@ at }
+        EActive {index = $4 c table; offset = $5 c; etype = $6; init = $7 c} @@ at }
 
 table :
   | LPAR TABLE bind_var_opt table_fields RPAR
@@ -642,7 +643,7 @@ table_fields :
       let init = $4 c func in
       let size = Lib.List32.length init in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ActiveWithIndices {index = x; offset; init} @@ at],
+      [EActive {index = x; offset; etype = FuncRefType; init} @@ at],
       [], [] }
 
 data :

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -593,30 +593,31 @@ elem :
   | LPAR ELEM bind_var_opt offset elemindex_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> ActiveIndices {index = 0l @@ at; offset = $4 c; init = $5 c func} @@ at }
+      fun () ->
+        ActiveWithIndices {index = 0l @@ at; offset = $4 c; init = $5 c func} @@ at }
   | LPAR ELEM bind_var_opt extern_kind elemindex_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> PassiveIndices {data = $5 c func} @@ at }
+      fun () -> PassiveWithIndices {data = $5 c func} @@ at }
   | LPAR ELEM bind_var_opt table_ref offset extern_kind elemindex_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      ActiveIndices {index = $4 c table; offset = $5 c; init = $7 c func} @@ at }
+      ActiveWithIndices {index = $4 c table; offset = $5 c; init = $7 c func} @@ at }
   | LPAR ELEM bind_var_opt offset elem_type elemref_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> ActiveRefs {index = 0l @@ at; offset = $4 c;
+      fun () -> ActiveWithRefs {index = 0l @@ at; offset = $4 c;
                             etype = $5; init = $6 c} @@ at }
   | LPAR ELEM bind_var_opt elem_type elemref_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> PassiveRefs {etype = $4; data = $5 c} @@ at }
+      fun () -> PassiveWithRefs {etype = $4; data = $5 c} @@ at }
   | LPAR ELEM bind_var_opt table_ref offset elem_type elemref_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ActiveRefs {index = $4 c table; offset = $5 c; etype = $6; init = $7 c} @@ at }
+        ActiveWithRefs {index = $4 c table; offset = $5 c; etype = $6; init = $7 c} @@ at }
 
 table :
   | LPAR TABLE bind_var_opt table_fields RPAR
@@ -641,7 +642,7 @@ table_fields :
       let init = $4 c func in
       let size = Lib.List32.length init in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ActiveIndices {index = x; offset; init} @@ at],
+      [ActiveWithIndices {index = x; offset; init} @@ at],
       [], [] }
 
 data :

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -566,7 +566,7 @@ func_body :
 
 /* Tables, Memories & Globals */
 
-table_ref :
+table_use :
   | LPAR TABLE var RPAR { fun c -> $3 c }
 
 offset :
@@ -576,47 +576,47 @@ offset :
 elem_kind :
   | FUNC { FuncRefType }
 
-elemref :
+elem_expr :
   | LPAR REF_NULL RPAR { let at = at () in fun c -> ref_null @@ at }
   | LPAR REF_FUNC var RPAR { let at = at () in fun c -> ref_func ($3 c func) @@ at }
 
-elemref_list :
+elem_expr_list :
   | /* empty */ { fun c -> [] }
-  | elemref elemref_list { fun c -> $1 c :: $2 c }
+  | elem_expr elem_expr_list { fun c -> $1 c :: $2 c }
 
-elemindex_list :
+elem_var_list :
   | var_list
     { let f = function {at; _} as x -> ref_func x @@ at in
       fun c lookup -> List.map f ($1 c lookup) }
 
 elem_list :
-  | elem_kind elemindex_list
+  | elem_kind elem_var_list
     { ($1, fun c -> $2 c func) }
-  | elem_type elemref_list
+  | elem_type elem_expr_list
     { ($1, fun c -> $2 c) }
 
 
 elem :
-  | LPAR ELEM bind_var_opt offset elemindex_list RPAR  /* Sugar */
+  | LPAR ELEM bind_var_opt offset elem_var_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ElemActive {index = 0l @@ at; offset = $4 c; etype = FuncRefType;
+        ActiveElem {index = 0l @@ at; offset = $4 c; etype = FuncRefType;
                            init = $5 c func} @@ at }
   | LPAR ELEM bind_var_opt elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> ElemPassive {etype = (fst $4); data = (snd $4) c} @@ at }
-  | LPAR ELEM bind_var_opt table_ref offset elem_list RPAR
+      fun () -> PassiveElem {etype = (fst $4); data = (snd $4) c} @@ at }
+  | LPAR ELEM bind_var_opt table_use offset elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ElemActive {index = $4 c table; offset = $5 c;
+        ActiveElem {index = $4 c table; offset = $5 c;
                     etype = (fst $6); init = (snd $6) c} @@ at }
   | LPAR ELEM bind_var_opt offset elem_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> ElemActive {index = 0l @@ at; offset = $4 c;
+      fun () -> ActiveElem {index = 0l @@ at; offset = $4 c;
                          etype = (fst $5); init = (snd $5) c} @@ at }
 
 table :
@@ -636,40 +636,40 @@ table_fields :
   | inline_export table_fields  /* Sugar */
     { fun c x at -> let tabs, elems, ims, exs = $2 c x at in
       tabs, elems, ims, $1 (TableExport x) c :: exs }
-  | elem_type LPAR ELEM elemindex_list RPAR  /* Sugar */
+  | elem_type LPAR ELEM elem_var_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
       let init = $4 c func in
       let size = Lib.List32.length init in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ElemActive {index = x; offset; etype = FuncRefType; init} @@ at],
+      [ActiveElem {index = x; offset; etype = FuncRefType; init} @@ at],
       [], [] }
-  | elem_type LPAR ELEM elemref elemref_list RPAR  /* Sugar */
+  | elem_type LPAR ELEM elem_expr elem_expr_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
       let init = (fun c -> $4 c :: $5 c) c in
       let size = Lib.List32.length init in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ElemActive {index = x; offset; etype = FuncRefType; init} @@ at],
+      [ActiveElem {index = x; offset; etype = FuncRefType; init} @@ at],
       [], [] }
 
 data :
   | LPAR DATA bind_var_opt string_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_data bind_data);
-      fun () -> DataPassive {data = $4} @@ at }
+      fun () -> PassiveData {data = $4} @@ at }
  | LPAR DATA bind_var var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (bind_data c $3);
-     fun () -> DataActive {index = $4 c memory; offset = $5 c; init = $6} @@ at }
+     fun () -> ActiveData {index = $4 c memory; offset = $5 c; init = $6} @@ at }
  | LPAR DATA var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (anon_data c);
-     fun () -> DataActive {index = $3 c memory; offset = $4 c; init = $5} @@ at }
+     fun () -> ActiveData {index = $3 c memory; offset = $4 c; init = $5} @@ at }
  | LPAR DATA offset string_list RPAR  /* Sugar */
    { let at = at () in
      fun c -> ignore (anon_data c);
-     fun () -> DataActive {index = 0l @@ at; offset = $3 c; init = $4} @@ at }
+     fun () -> ActiveData {index = 0l @@ at; offset = $3 c; init = $4} @@ at }
 
 memory :
   | LPAR MEMORY bind_var_opt memory_fields RPAR
@@ -693,7 +693,7 @@ memory_fields :
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
       let size = Int32.(div (add (of_int (String.length $3)) 65535l) 65536l) in
       [{mtype = MemoryType {min = size; max = Some size}} @@ at],
-      [DataActive {index = x; offset; init = $3} @@ at],
+      [ActiveData {index = x; offset; init = $3} @@ at],
       [], [] }
 
 global :

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -429,19 +429,19 @@ let check_elemref (c : context) (el : elem) =
 
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
-  | EActive {index; offset; init; _} ->
+  | ElemActive {index; offset; init; _} ->
     ignore (table c index);
     check_const c offset I32Type;
     List.iter (check_elemref c) init
-  | PassiveWithRefs {data; _} ->
+  | ElemPassive {data; _} ->
     List.iter (check_elemref c) data
 
 let check_data (c : context) (seg : memory_segment) =
   match seg.it with
-  | Active {index; offset; init} ->
+  | DataActive {index; offset; init} ->
     ignore (memory c index);
     check_const c offset I32Type
-  | Passive init -> ()
+  | DataPassive init -> ()
 
 let check_global (c : context) (glob : global) =
   let {gtype; value} = glob.it in

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -429,11 +429,13 @@ let check_elemref (c : context) (el : elem) =
 
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
-  | Active {index; offset; init} ->
+  | ActiveIndices {index; offset; init}
+  | ActiveRefs {index; offset; init; _} ->
     ignore (table c index);
     check_const c offset I32Type;
     List.iter (check_elemref c) init
-  | Passive {etype; data} ->
+  | PassiveIndices {data}
+  | PassiveRefs {data; _} ->
     List.iter (check_elemref c) data
 
 let check_data (c : context) (seg : memory_segment) =

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -429,13 +429,13 @@ let check_elemref (c : context) (el : elem) =
 
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
-  | ActiveIndices {index; offset; init}
-  | ActiveRefs {index; offset; init; _} ->
+  | ActiveWithIndices {index; offset; init}
+  | ActiveWithRefs {index; offset; init; _} ->
     ignore (table c index);
     check_const c offset I32Type;
     List.iter (check_elemref c) init
-  | PassiveIndices {data}
-  | PassiveRefs {data; _} ->
+  | PassiveWithIndices {data}
+  | PassiveWithRefs {data; _} ->
     List.iter (check_elemref c) data
 
 let check_data (c : context) (seg : memory_segment) =

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -429,12 +429,10 @@ let check_elemref (c : context) (el : elem) =
 
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
-  | ActiveWithIndices {index; offset; init}
-  | ActiveWithRefs {index; offset; init; _} ->
+  | EActive {index; offset; init; _} ->
     ignore (table c index);
     check_const c offset I32Type;
     List.iter (check_elemref c) init
-  | PassiveWithIndices {data}
   | PassiveWithRefs {data; _} ->
     List.iter (check_elemref c) data
 

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -429,19 +429,19 @@ let check_elemref (c : context) (el : elem) =
 
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
-  | ElemActive {index; offset; init; _} ->
+  | ActiveElem {index; offset; init; _} ->
     ignore (table c index);
     check_const c offset I32Type;
     List.iter (check_elemref c) init
-  | ElemPassive {data; _} ->
+  | PassiveElem {data; _} ->
     List.iter (check_elemref c) data
 
 let check_data (c : context) (seg : memory_segment) =
   match seg.it with
-  | DataActive {index; offset; init} ->
+  | ActiveData {index; offset; init} ->
     ignore (memory c index);
     check_const c offset I32Type
-  | DataPassive init -> ()
+  | PassiveData init -> ()
 
 let check_global (c : context) (glob : global) =
   let {gtype; value} = glob.it in

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -733,7 +733,7 @@
     "\05\03\01\00\00"          ;; Memory section
 
     "\09\07\01"                ;; Element section with one segment
-    "\01\70"                   ;; Passive, funcref
+    "\05\70"                   ;; Passive, funcref
     "\01"                      ;; 1 element
     "\d3\00\0b"                ;; bad opcode, index 0, end
 
@@ -759,7 +759,7 @@
     "\05\03\01\00\00"          ;; Memory section
 
     "\09\07\01"                ;; Element section with one segment
-    "\01\7f"                   ;; Passive, i32
+    "\05\7f"                   ;; Passive, i32
     "\01"                      ;; 1 element
     "\d2\00\0b"                ;; ref.func, index 0, end
 
@@ -784,7 +784,7 @@
   "\05\03\01\00\00"          ;; Memory section
 
   "\09\07\01"                ;; Element section with one segment
-  "\01\70"                   ;; Passive, funcref
+  "\05\70"                   ;; Passive, funcref
   "\01"                      ;; 1 element
   "\d2\00\0b"                ;; ref.func, index 0, end
 
@@ -808,7 +808,7 @@
   "\05\03\01\00\00"          ;; Memory section
 
   "\09\06\01"                ;; Element section with one segment
-  "\01\70"                   ;; Passive, funcref
+  "\05\70"                   ;; Passive, funcref
   "\01"                      ;; 1 element
   "\d0\0b"                   ;; ref.null, end
 

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -215,7 +215,7 @@
   (table 1 funcref)
   (func $f)
   (elem $p funcref (ref.func $f))
-  (elem $a 0 (i32.const 0) $f)
+  (elem $a (table 0) (i32.const 0) func $f)
 
   (func (export "drop_passive") (elem.drop $p))
   (func (export "init_passive")

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -25,8 +25,8 @@
   (elem (table $t) (offset (i32.const 0)) func)
   (elem (table $t) (offset (i32.const 0)) func $f $f)
 
-  (elem (i32.const 3) (ref.func $f) (ref.func $g) (ref.func $f))
-  (elem (i32.const 3) (ref.func $f) (ref.null) (ref.func $f))
+  (elem (i32.const 3) funcref (ref.func $f) (ref.func $g) (ref.func $f))
+  (elem (i32.const 3) funcref (ref.func $f) (ref.null) (ref.func $f))
 
   (elem funcref (ref.func $f) (ref.func $g) (ref.func $f))
   (elem funcref (ref.func $f) (ref.func $g) (ref.null))

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -4,18 +4,35 @@
 (module
   (table $t 10 funcref)
   (func $f)
+  (func $g)
+  (elem (table $t) (i32.const 0) func)
   (elem (i32.const 0))
   (elem (i32.const 0) $f $f)
   (elem (offset (i32.const 0)))
   (elem (offset (i32.const 0)) $f $f)
-  (elem 0 (i32.const 0))
-  (elem 0x0 (i32.const 0) $f $f)
-  (elem 0x000 (offset (i32.const 0)))
-  (elem 0 (offset (i32.const 0)) $f $f)
-  (elem $t (i32.const 0))
-  (elem $t (i32.const 0) $f $f)
-  (elem $t (offset (i32.const 0)))
-  (elem $t (offset (i32.const 0)) $f $f)
+
+  (elem func)
+  (elem $s func)
+  (elem func $f $f $g $g)
+  (elem $x func $f $f $g $g)
+
+  (elem (table 0) (i32.const 0) func)
+  (elem (table 0x0) (i32.const 0) func $f $f)
+  (elem (table 0x000) (offset (i32.const 0)) func)
+  (elem (table 0) (offset (i32.const 0)) func $f $f)
+  (elem (table $t) (i32.const 0) func)
+  (elem (table $t) (i32.const 0) func $f $f)
+  (elem (table $t) (offset (i32.const 0)) func)
+  (elem (table $t) (offset (i32.const 0)) func $f $f)
+
+  (elem (i32.const 3) funcref (ref.func $f) (ref.func $g) (ref.func $f))
+  (elem (i32.const 3) funcref (ref.func $f) (ref.null) (ref.func $f))
+
+  (elem funcref (ref.func $f) (ref.func $g) (ref.func $f))
+  (elem funcref (ref.func $f) (ref.func $g) (ref.null))
+
+  (elem (table $t) (i32.const 3) funcref (ref.func $f) (ref.func $g) (ref.func $f))
+  (elem (table $t) (i32.const 3) funcref (ref.func $f) (ref.null) (ref.func $g))
 )
 
 ;; Basic use

--- a/test/core/elem.wast
+++ b/test/core/elem.wast
@@ -25,8 +25,8 @@
   (elem (table $t) (offset (i32.const 0)) func)
   (elem (table $t) (offset (i32.const 0)) func $f $f)
 
-  (elem (i32.const 3) funcref (ref.func $f) (ref.func $g) (ref.func $f))
-  (elem (i32.const 3) funcref (ref.func $f) (ref.null) (ref.func $f))
+  (elem (i32.const 3) (ref.func $f) (ref.func $g) (ref.func $f))
+  (elem (i32.const 3) (ref.func $f) (ref.null) (ref.func $f))
 
   (elem funcref (ref.func $f) (ref.func $g) (ref.func $f))
   (elem funcref (ref.func $f) (ref.func $g) (ref.null))
@@ -35,6 +35,12 @@
   (elem (table $t) (i32.const 3) funcref (ref.func $f) (ref.null) (ref.func $g))
 )
 
+(module
+  (func $f)
+  (func $g)
+
+  (table $t funcref (elem (ref.func $f) (ref.null) (ref.func $g)))
+)
 ;; Basic use
 
 (module

--- a/test/core/imports.wast
+++ b/test/core/imports.wast
@@ -271,7 +271,7 @@
 (module
   (type (func (result i32)))
   (import "spectest" "table" (table 10 20 funcref))
-  (elem 0 (i32.const 1) $f $g)
+  (elem (table 0) (i32.const 1) func $f $g)
 
   (func (export "call") (param i32) (result i32)
     (call_indirect (type 0) (local.get 0))
@@ -290,7 +290,7 @@
 (module
   (type (func (result i32)))
   (table (import "spectest" "table") 10 20 funcref)
-  (elem 0 (i32.const 1) $f $g)
+  (elem (table 0) (i32.const 1) func $f $g)
 
   (func (export "call") (param i32) (result i32)
     (call_indirect (type 0) (local.get 0))


### PR DESCRIPTION
This PR implements https://github.com/WebAssembly/bulk-memory-operations/issues/98:
* Extend the interpreter to handle the new element segment encoding;
* Add tests for the new element segment encoding;
* Adjust the text format specification;

The text format for case `0x1` needs the `func` keyword as a separator between a potential segment identifier and the function indices.

The text format needs a more verbose table index to distinguish between a potential segment identifier and the table index in case `0x2`. Alternatively we could just disallow table identifiers for active segments, since they are not useful anyways.

also-by: thibaudm@chromium.org