### PR TITLE
Fix the binary.wast test for multi-bytes table indices

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -637,32 +637,32 @@ let elem_refs s =
   vec (at elem_expr) s
 
 let table_segment s =
-  match vu32 s with
-  | 0l ->
+  match u8 s with
+  | 0 ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = elem_indices s in
     ActiveElem {index; offset; etype = FuncRefType; init}
-  | 1l ->
+  | 1 ->
     let etype = elem_kind s in
     let data = elem_indices s in
     PassiveElem {etype; data}
-  | 2l ->
+  | 2 ->
     let index = at var s in
     let offset = const s in
     let etype = elem_kind s in
     let init = elem_indices s in
     ActiveElem {index; offset; etype; init}
-  | 4l ->
+  | 4 ->
     let index = Source.(0l @@ Source.no_region) in
     let offset = const s in
     let init = elem_refs s in
     ActiveElem {index; offset; etype = FuncRefType; init}
-  | 5l ->
+  | 5 ->
     let etype = elem_type s in
     let data = elem_refs s in
     PassiveElem {etype; data}
-  | 6l ->
+  | 6 ->
     let index = at var s in
     let offset = const s in
     let etype = elem_type s in

--- a/test/core/binary.wast
+++ b/test/core/binary.wast
@@ -129,9 +129,9 @@
   "\00asm" "\01\00\00\00"
   "\04\04\01"                          ;; Table section with 1 entry
   "\70\00\00"                          ;; no max, minimum 0, funcref
-  "\09\07\01"                          ;; Element section with 1 entry
-  "\80\00"                             ;; Table index 0, encoded with 2 bytes
-  "\41\00\0b\00"                       ;; (i32.const 0) with no elements
+  "\09\09\01"                          ;; Element section with 1 entry
+  "\02\80\00"                          ;; Table index 0, encoded with 2 bytes
+  "\41\00\0b\00\00"                    ;; (i32.const 0) with no elements
 )
 
 ;; Unsigned LEB128 must not be overlong


### PR DESCRIPTION
One test in binary.wast checked if the table index can be encoded as varint. However, it encoded the table index not in the table index field but in the flag field. I fixed that now, and I also fixed the decoder to not accept varints as the flag field anymore.