### PR TITLE
Segment refactoring

### DIFF
--- a/document/core/appendix/index-rules.rst
+++ b/document/core/appendix/index-rules.rst
@@ -25,8 +25,10 @@ Construct                                        Judgement
 :ref:`Table <valid-table>`                       :math:`C \vdashtable \table : \tabletype`
 :ref:`Memory <valid-mem>`                        :math:`C \vdashmem \mem : \memtype`
 :ref:`Global <valid-global>`                     :math:`C \vdashglobal \global : \globaltype`
-:ref:`Element segment <valid-elem>`              :math:`C \vdashelem \elem \ok`
-:ref:`Data segment <valid-data>`                 :math:`C \vdashdata \data \ok`
+:ref:`Element segment <valid-elem>`              :math:`C \vdashelem \elem : \segtype`
+:ref:`Element mode <valid-elemmode>`             :math:`C \vdashelemmode \elemmode : \segtype`
+:ref:`Data segment <valid-data>`                 :math:`C \vdashdata \data : \segtype`
+:ref:`Data mode <valid-datamode>`                :math:`C \vdashdatamode \datamode : \segtype`
 :ref:`Start function <valid-start>`              :math:`C \vdashstart \start \ok`
 :ref:`Export <valid-export>`                     :math:`C \vdashexport \export : \externtype`
 :ref:`Export description <valid-exportdesc>`     :math:`C \vdashexportdesc \exportdesc : \externtype`

--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -328,18 +328,18 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
    \production{element section} & \Belemsec &::=&
      \X{seg}^\ast{:}\Bsection_9(\Bvec(\Belem)) &\Rightarrow& \X{seg} \\
    \production{element segment} & \Belem &::=&
-     \hex{00}~~o{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
-       &\Rightarrow& \{ \ETABLE~0, \EOFFSET~o, \ETYPE~\FUNCREF, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
+     \hex{00}~~e{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
+       &\Rightarrow& \{ \ETYPE~\FUNCREF, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EACTIVE~\{ \ETABLE~0, \EOFFSET~e \} \} \\ &&|&
      \hex{01}~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
-       &\Rightarrow& \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
-     \hex{02}~~x{:}\Btableidx~~o{:}\Bexpr~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
-       &\Rightarrow& \{ \ETABLE~x, \EOFFSET~o, \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
-     \hex{04}~~o{:}\Bexpr~e^\ast{:}\Bvec(\Belemexpr)
-       &\Rightarrow& \{ \ETABLE~0, \EOFFSET~o, \ETYPE~\FUNCREF, \EINIT~e^\ast \} \\ &&|&
-     \hex{05}~~\X{et}:\Belemtype~~e^\ast{:}\Bvec(\Belemexpr)
-       &\Rightarrow& \{ \ETYPE~et, \EINIT~e^\ast \} \\ &&|&
-     \hex{06}~~x{:}\Btableidx~~o{:}\Bexpr~~\X{et}:\Belemtype~~e^\ast{:}\Bvec(\Belemexpr)
-       &\Rightarrow& \{ \ETABLE~x, \EOFFSET~o, \ETYPE~et, \EINIT~e^\ast \} \\
+       &\Rightarrow& \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EPASSIVE \} \\ &&|&
+     \hex{02}~~x{:}\Btableidx~~e{:}\Bexpr~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
+       &\Rightarrow& \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast, \EMODE~\EACTIVE~\{ \ETABLE~x, \EOFFSET~e \} \} \\ &&|&
+     \hex{04}~~e{:}\Bexpr~~\X{el}^\ast{:}\Bvec(\Belemexpr)
+       &\Rightarrow& \{ \ETYPE~\FUNCREF, \EINIT~\X{el}^\ast, \EMODE~\EACTIVE~\{ \ETABLE~0, \EOFFSET~e \} \} \\ &&|&
+     \hex{05}~~\X{et}:\Belemtype~~\X{el}^\ast{:}\Bvec(\Belemexpr)
+       &\Rightarrow& \{ \ETYPE~et, \EINIT~\X{el}^\ast, \EMODE~\EPASSIVE \} \\ &&|&
+     \hex{06}~~x{:}\Btableidx~~e{:}\Bexpr~~\X{et}:\Belemtype~~\X{el}^\ast{:}\Bvec(\Belemexpr)
+       &\Rightarrow& \{ \ETYPE~et, \EINIT~\X{el}^\ast, \EMODE~\EACTIVE~\{ \ETABLE~x, \EOFFSET~e \} \} \\
    \production{element kind} & \Belemkind &::=&
      \hex{00} &\Rightarrow& \FUNCREF \\
    \production{element expression} & \Belemexpr &::=&
@@ -437,11 +437,11 @@ It decodes into a vector of :ref:`data segments <syntax-data>` that represent th
      \X{seg}^\ast{:}\Bsection_{11}(\Bvec(\Bdata)) &\Rightarrow& \X{seg} \\
    \production{data segment} & \Bdata &::=&
      \hex{00}~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
-       &\Rightarrow& \{ \DMEM~0, \DOFFSET~e, \DINIT~b^\ast \} \\ &&|&
+       &\Rightarrow& \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~0, \DOFFSET~e \} \} \\ &&|&
      \hex{01}~~b^\ast{:}\Bvec(\Bbyte)
-       &\Rightarrow& \{ \DINIT~b^\ast \} \\ &&|&
+       &\Rightarrow& \{ \DINIT~b^\ast, \DMODE~\DPASSIVE \} \\ &&|&
      \hex{02}~~x{:}\Bmemidx~~e{:}\Bexpr~~b^\ast{:}\Bvec(\Bbyte)
-       &\Rightarrow& \{ \DMEM~x, \DOFFSET~e, \DINIT~b^\ast \} \\
+       &\Rightarrow& \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~x, \DOFFSET~e \} \} \\
    \end{array}
 
 .. note::

--- a/document/core/binary/modules.rst
+++ b/document/core/binary/modules.rst
@@ -314,6 +314,7 @@ It decodes into an optional :ref:`start function <syntax-start>` that represents
    single: element; segment
 .. _binary-elem:
 .. _binary-elemsec:
+.. _binary-elemkind:
 .. _binary-elemexpr:
 
 Element Section
@@ -329,25 +330,34 @@ It decodes into a vector of :ref:`element segments <syntax-elem>` that represent
    \production{element segment} & \Belem &::=&
      \hex{00}~~o{:}\Bexpr~~y^\ast{:}\Bvec(\Bfuncidx)
        &\Rightarrow& \{ \ETABLE~0, \EOFFSET~o, \ETYPE~\FUNCREF, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
-     \hex{01}~~\hex{00}~~y^\ast{:}\Bvec(\Bfuncidx)
-       &\Rightarrow& \{ \ETYPE~\FUNCREF, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
-     \hex{02}~~x{:}\Btableidx~~o{:}\Bexpr~~\hex{00}~~y^\ast{:}\Bvec(\Bfuncidx)
-       &\Rightarrow& \{ \ETABLE~x, \EOFFSET~o, \ETYPE~\FUNCREF, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
+     \hex{01}~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
+       &\Rightarrow& \{ \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
+     \hex{02}~~x{:}\Btableidx~~o{:}\Bexpr~~\X{et}:\Belemkind~~y^\ast{:}\Bvec(\Bfuncidx)
+       &\Rightarrow& \{ \ETABLE~x, \EOFFSET~o, \ETYPE~\X{et}, \EINIT~((\REFFUNC~y)~\END)^\ast \} \\ &&|&
      \hex{04}~~o{:}\Bexpr~e^\ast{:}\Bvec(\Belemexpr)
        &\Rightarrow& \{ \ETABLE~0, \EOFFSET~o, \ETYPE~\FUNCREF, \EINIT~e^\ast \} \\ &&|&
      \hex{05}~~\X{et}:\Belemtype~~e^\ast{:}\Bvec(\Belemexpr)
        &\Rightarrow& \{ \ETYPE~et, \EINIT~e^\ast \} \\ &&|&
      \hex{06}~~x{:}\Btableidx~~o{:}\Bexpr~~\X{et}:\Belemtype~~e^\ast{:}\Bvec(\Belemexpr)
        &\Rightarrow& \{ \ETABLE~x, \EOFFSET~o, \ETYPE~et, \EINIT~e^\ast \} \\
-   \production{elemexpr} & \Belemexpr &::=&
+   \production{element kind} & \Belemkind &::=&
+     \hex{00} &\Rightarrow& \FUNCREF \\
+   \production{element expression} & \Belemexpr &::=&
      \hex{D0}~\hex{0B} &\Rightarrow& \REFNULL~\END \\ &&|&
      \hex{D2}~x{:}\Bfuncidx~\hex{0B} &\Rightarrow& (\REFFUNC~x)~\END \\
    \end{array}
 
 .. note::
+   The initial byte can be interpreted as a bitfield.
+   Bit 0 indicates a passive segment,
+   bit 1 indicates the presence of an explicit table index for an active segment,
+   bit 2 indicates the use of element type and element expressions instead of element kind and element indices.
+
    In the current version of WebAssembly, at most one table may be defined or
    imported in a single module, so all valid :ref:`active <syntax-active>`
    element segments have a |ETABLE| value of :math:`0`.
+
+   Additional element kinds may be added in future versions of WebAssembly.
 
 
 .. index:: ! code section, function, local, type index, function type
@@ -435,6 +445,10 @@ It decodes into a vector of :ref:`data segments <syntax-data>` that represent th
    \end{array}
 
 .. note::
+   The initial byte can be interpreted as a bitfield.
+   Bit 0 indicates a passive segment,
+   bit 1 indicates the presence of an explicit memory index for an active segment.
+
    In the current version of WebAssembly, at most one memory may be defined or
    imported in a single module, so all valid :ref:`active <syntax-active>` data
    segments have a |DMEM| value of :math:`0`.

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -667,7 +667,7 @@ Memory Instructions
 
 17. Execute the instruction :math:`\MEMORYFILL`.
 
-18. Push the value :math:`\vconst_\I32(i+1)` to the stack.
+18. Push the value :math:`\vconst_{\I32}(i+1)` to the stack.
 
 19. Push the value :math:`\val` to the stack.
 
@@ -688,7 +688,7 @@ Memory Instructions
    S; F; (\I32.\CONST~i)~\val~(\I32.\CONST~n)~(\MEMORYFILL) &\stepto& S; F;
      \begin{array}[t]{@{}l@{}}
      (\I32.\CONST~i)~\val~(\I32.\CONST~1)~(\MEMORYFILL) \\
-     (\vconst_\I32(i+1))~\val~(\I32.\CONST~(n-1))~(\MEMORYFILL) \\
+     (\vconst_{\I32}(i+1))~\val~(\I32.\CONST~(n-1))~(\MEMORYFILL) \\
      \end{array} \\
    \end{array}
    \\ \qquad
@@ -763,9 +763,9 @@ Memory Instructions
 
 22. Execute the instruction :math:`\MEMORYINIT~x`.
 
-23. Push the value :math:`\vconst_\I32(dst+1)` to the stack.
+23. Push the value :math:`\vconst_{\I32}(dst+1)` to the stack.
 
-24. Push the value :math:`\vconst_\I32(src+1)` to the stack.
+24. Push the value :math:`\vconst_{\I32}(src+1)` to the stack.
 
 25. Push the value :math:`\I32.\CONST~(cnt-1)` to the stack.
 
@@ -792,7 +792,7 @@ Memory Instructions
    S; F; (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~cnt))~(\MEMORYINIT~x) &\stepto& S; F;
      \begin{array}[t]{@{}l@{}}
      (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~1)~(\MEMORYINIT~x) \\
-     (\vconst_\I32(dst+1))~(\vconst_\I32(src+1))~(\I32.\CONST~(cnt-1))~(\MEMORYINIT~x) \\
+     (\vconst_{\I32}(dst+1))~(\vconst_{\I32}(src+1))~(\I32.\CONST~(cnt-1))~(\MEMORYINIT~x) \\
      \end{array} \\
    \end{array}
    \\ \qquad
@@ -890,15 +890,15 @@ Memory Instructions
 
    d. Execute the instruction :math:`\MEMORYCOPY`.
 
-   e. Push the value :math:`\vconst_\I32(dst+1)` to the stack.
+   e. Push the value :math:`\vconst_{\I32}(dst+1)` to the stack.
 
-   f. Push the value :math:`\vconst_\I32(src+1)` to the stack.
+   f. Push the value :math:`\vconst_{\I32}(src+1)` to the stack.
 
 10. Else:
 
-   a. Push the value :math:`\vconst_\I32(dst+cnt-1)` to the stack.
+   a. Push the value :math:`\vconst_{\I32}(dst+cnt-1)` to the stack.
 
-   b. Push the value :math:`\vconst_\I32(src+cnt-1)` to the stack.
+   b. Push the value :math:`\vconst_{\I32}(src+cnt-1)` to the stack.
 
    c. Push the value :math:`\I32.\CONST~1` to the stack.
 
@@ -932,7 +932,7 @@ Memory Instructions
    S; F; (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~cnt)~\MEMORYCOPY &\stepto& S; F;
      \begin{array}[t]{@{}l@{}}
      (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~1)~\MEMORYCOPY \\
-     (\vconst_\I32(dst+1))~(\vconst_\I32(src+1))~(\I32.\CONST~(cnt-1))~\MEMORYCOPY \\
+     (\vconst_{\I32}(dst+1))~(\vconst_{\I32}(src+1))~(\I32.\CONST~(cnt-1))~\MEMORYCOPY \\
      \end{array} \\
    \end{array}
    \\ \qquad
@@ -1001,15 +1001,15 @@ Table Instructions
 
    d. Execute the instruction :math:`\TABLECOPY`.
 
-   e. Push the value :math:`\vconst_\I32(dst+1)` to the stack.
+   e. Push the value :math:`\vconst_{\I32}(dst+1)` to the stack.
 
-   f. Push the value :math:`\vconst_\I32(src+1)` to the stack.
+   f. Push the value :math:`\vconst_{\I32}(src+1)` to the stack.
 
 10. Else:
 
-   a. Push the value :math:`\vconst_\I32(dst+cnt-1)` to the stack.
+   a. Push the value :math:`\vconst_{\I32}(dst+cnt-1)` to the stack.
 
-   b. Push the value :math:`\vconst_\I32(src+cnt-1)` to the stack.
+   b. Push the value :math:`\vconst_{\I32}(src+cnt-1)` to the stack.
 
    c. Push the value :math:`\I32.\CONST~1` to the stack.
 
@@ -1039,7 +1039,7 @@ Table Instructions
    S; F; (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~cnt)~\TABLECOPY &\stepto& S; F;
      \begin{array}[t]{@{}l@{}}
      (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~1)~\TABLECOPY \\
-     (\vconst_\I32(dst+1))~(\vconst_\I32(src+1))~(\I32.\CONST~(cnt-1))~\TABLECOPY \\
+     (\vconst_{\I32}(dst+1))~(\vconst_{\I32}(src+1))~(\I32.\CONST~(cnt-1))~\TABLECOPY \\
      \end{array} \\
    \end{array}
    \\ \qquad
@@ -1124,9 +1124,9 @@ Table Instructions
 
 22. Execute the instruction :math:`\TABLEINIT~x`.
 
-23. Push the value :math:`\vconst_\I32(dst+1)` to the stack.
+23. Push the value :math:`\vconst_{\I32}(dst+1)` to the stack.
 
-24. Push the value :math:`\vconst_\I32(src+1)` to the stack.
+24. Push the value :math:`\vconst_{\I32}(src+1)` to the stack.
 
 25. Push the value :math:`\I32.\CONST~(cnt-1)` to the stack.
 
@@ -1153,7 +1153,7 @@ Table Instructions
    S; F; (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~cnt)~(\TABLEINIT~x) &\stepto& S; F;
      \begin{array}[t]{@{}l@{}}
      (\I32.\CONST~dst)~(\I32.\CONST~src)~(\I32.\CONST~1)~(\TABLEINIT~x) \\
-     (\vconst_\I32(dst+1))~(\vconst_\I32(src+1))~(\I32.\CONST~(cnt-1))~(\TABLEINIT~x) \\
+     (\vconst_{\I32}(dst+1))~(\vconst_{\I32}(src+1))~(\I32.\CONST~(cnt-1))~(\TABLEINIT~x) \\
      \end{array} \\
    \end{array}
    \\ \qquad

--- a/document/core/exec/instructions.rst
+++ b/document/core/exec/instructions.rst
@@ -711,11 +711,11 @@ Memory Instructions
 
 5. Let :math:`\X{mem}` be the :ref:`memory instance <syntax-meminst>` :math:`S.\SMEMS[\X{ma}]`.
 
-6. Assert: due to :ref:`validation <valid-data.init>`, :math:`F.\AMODULE.\MIDATAS[x]` exists.
+6. Assert: due to :ref:`validation <valid-memory.init>`, :math:`F.\AMODULE.\MIDATAS[x]` exists.
 
 7. Let :math:`\X{da}` be the :ref:`data address <syntax-dataaddr>` :math:`F.\AMODULE.\MIDATAS[x]`.
 
-8. Assert: due to :ref:`validation <valid-data.init>`, :math:`S.\SDATA[\X{da}]` exists.
+8. Assert: due to :ref:`validation <valid-memory.init>`, :math:`S.\SDATA[\X{da}]` exists.
 
 9. Let :math:`\X{data}^?` be the optional :ref:`data instance <syntax-datainst>` :math:`S.\SDATA[\X{da}]`.
 
@@ -813,11 +813,11 @@ Memory Instructions
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-data.init>`, :math:`F.\AMODULE.\MIDATAS[x]` exists.
+2. Assert: due to :ref:`validation <valid-data.drop>`, :math:`F.\AMODULE.\MIDATAS[x]` exists.
 
 3. Let :math:`a` be the :ref:`data address <syntax-dataaddr>` :math:`F.\AMODULE.\MIDATAS[x]`.
 
-4. Assert: due to :ref:`validation <valid-data.init>`, :math:`S.\SDATA[a]` exists.
+4. Assert: due to :ref:`validation <valid-data.drop>`, :math:`S.\SDATA[a]` exists.
 
 5. Let :math:`\X{data}^?` be the optional :ref:`data instance <syntax-datainst>` :math:`S.\SDATA[a]`.
 
@@ -1072,11 +1072,11 @@ Table Instructions
 
 5. Let :math:`\X{tab}` be the :ref:`table instance <syntax-tableinst>` :math:`S.\STABLES[\X{ta}]`.
 
-6. Assert: due to :ref:`validation <valid-elem.init>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
+6. Assert: due to :ref:`validation <valid-table.init>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
 
 7. Let :math:`\X{ea}` be the :ref:`element address <syntax-elemaddr>` :math:`F.\AMODULE.\MIELEMS[x]`.
 
-8. Assert: due to :ref:`validation <valid-elem.init>`, :math:`S.\SELEM[\X{ea}]` exists.
+8. Assert: due to :ref:`validation <valid-table.init>`, :math:`S.\SELEM[\X{ea}]` exists.
 
 9. Let :math:`\X{elem}^?` be the optional :ref:`element instance <syntax-eleminst>` :math:`S.\SELEM[\X{ea}]`.
 
@@ -1174,11 +1174,11 @@ Table Instructions
 
 1. Let :math:`F` be the :ref:`current <exec-notation-textual>` :ref:`frame <syntax-frame>`.
 
-2. Assert: due to :ref:`validation <valid-elem.init>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
+2. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`F.\AMODULE.\MIELEMS[x]` exists.
 
 3. Let :math:`a` be the :ref:`element address <syntax-elemaddr>` :math:`F.\AMODULE.\MIELEMS[x]`.
 
-4. Assert: due to :ref:`validation <valid-elem.init>`, :math:`S.\SELEM[a]` exists.
+4. Assert: due to :ref:`validation <valid-elem.drop>`, :math:`S.\SELEM[a]` exists.
 
 5. Let :math:`\X{elem}^?` be the optional :ref:`elem instance <syntax-eleminst>` :math:`S.\SELEM[a]`.
 

--- a/document/core/exec/modules.rst
+++ b/document/core/exec/modules.rst
@@ -614,6 +614,8 @@ Moreover, if the dots :math:`\dots` are a sequence :math:`A^n` (as for globals),
 Instantiation
 ~~~~~~~~~~~~~
 
+.. todo:: Adjust for passive segments.
+
 Given a :ref:`store <syntax-store>` :math:`S`, a :ref:`module <syntax-module>` :math:`\module` is instantiated with a list of :ref:`external values <syntax-externval>` :math:`\externval^n` supplying the required imports as follows.
 
 Instantiation checks that the module is :ref:`valid <valid>` and the provided imports :ref:`match <match-externtype>` the declared types,
@@ -665,47 +667,43 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 8. Push the frame :math:`F` to the stack.
 
-9. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
+9. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM` whose :ref:`mode <syntax-elemmode>` :math:`\elem_i.\EMODE` is of the form :math:`\EACTIVE~\{ \ETABLE~\tableidx_i, \EOFFSET~\X{eoexpr}_i \}`, do:
 
-    a. Let :math:`\X{eoval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\elem_i.\EOFFSET`.
+    a. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
 
-    b. Assert: due to :ref:`validation <valid-elem>`, :math:`\X{eoval}_i` is of the form :math:`\I32.\CONST~\X{eo}_i`.
+    b. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
 
-    c. Let :math:`\tableidx_i` be the :ref:`table index <syntax-tableidx>` :math:`\elem_i.\ETABLE`.
+    c. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
 
-    d. Assert: due to :ref:`validation <valid-elem>`, :math:`\moduleinst.\MITABLES[\tableidx_i]` exists.
+    d. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
 
-    e. Let :math:`\tableaddr_i` be the :ref:`table address <syntax-tableaddr>` :math:`\moduleinst.\MITABLES[\tableidx_i]`.
+    e. Let :math:`\X{eoval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\X{eoexpr}_i`.
 
-    f. Assert: due to :ref:`validation <valid-elem>`, :math:`S'.\STABLES[\tableaddr_i]` exists.
+    f. Assert: due to :ref:`validation <valid-elem>`, :math:`\X{eoval}_i` is of the form :math:`\I32.\CONST~\X{eo}_i`.
 
-    g. Let :math:`\tableinst_i` be the :ref:`table instance <syntax-tableinst>` :math:`S'.\STABLES[\tableaddr_i]`.
+    g. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
 
-    h. Let :math:`\X{eend}_i` be :math:`\X{eo}_i` plus the length of :math:`\elem_i.\EINIT`.
-
-    i. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
+    h. If :math:`\X{eend}_i` is larger than the length of :math:`\tableinst_i.\TIELEM`, then:
 
        i. Fail.
 
-10. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
+10. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA` whose :ref:`mode <syntax-datamode>` :math:`\data_i.\DMODE` is of the form :math:`\DACTIVE~\{ \DMEM~\memidx_i, \DOFFSET~\X{doexpr}_i \}`, do:
 
-    a. Let :math:`\X{doval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
+    a. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
 
-    b. Assert: due to :ref:`validation <valid-data>`, :math:`\X{doval}_i` is of the form :math:`\I32.\CONST~\X{do}_i`.
+    b. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
 
-    c. Let :math:`\memidx_i` be the :ref:`memory index <syntax-memidx>` :math:`\data_i.\DMEM`.
+    c. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
 
-    d. Assert: due to :ref:`validation <valid-data>`, :math:`\moduleinst.\MIMEMS[\memidx_i]` exists.
+    d. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
 
-    e. Let :math:`\memaddr_i` be the :ref:`memory address <syntax-memaddr>` :math:`\moduleinst.\MIMEMS[\memidx_i]`.
+    e. Let :math:`\X{doval}_i` be the result of :ref:`evaluating <exec-expr>` the expression :math:`\data_i.\DOFFSET`.
 
-    f. Assert: due to :ref:`validation <valid-data>`, :math:`S'.\SMEMS[\memaddr_i]` exists.
+    f. Assert: due to :ref:`validation <valid-data>`, :math:`\X{doval}_i` is of the form :math:`\I32.\CONST~\X{do}_i`.
 
-    g. Let :math:`\meminst_i` be the :ref:`memory instance <syntax-meminst>` :math:`S'.\SMEMS[\memaddr_i]`.
+    g. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
 
-    h. Let :math:`\X{dend}_i` be :math:`\X{do}_i` plus the length of :math:`\data_i.\DINIT`.
-
-    i. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
+    h. If :math:`\X{dend}_i` is larger than the length of :math:`\meminst_i.\MIDATA`, then:
 
        i. Fail.
 
@@ -713,7 +711,7 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
 12. Pop the frame from the stack.
 
-13. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM`, do:
+13. For each :ref:`element segment <syntax-elem>` :math:`\elem_i` in :math:`\module.\MELEM` whose :ref:`mode <syntax-elemmode>` :math:`\elem_i.\EMODE` is of the form :math:`\EACTIVE~\{ \ETABLE~\tableidx_i, \EOFFSET~\X{eoexpr}_i \}`, do:
 
     a. For each :ref:`function index <syntax-funcidx>` :math:`\funcidx_{ij}` in :math:`\elem_i.\EINIT` (starting with :math:`j = 0`), do:
 
@@ -723,7 +721,7 @@ It is up to the :ref:`embedder <embedder>` to define how such conditions are rep
 
        iii. Replace :math:`\tableinst_i.\TIELEM[\X{eo}_i + j]` with :math:`\funcaddr_{ij}`.
 
-14. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA`, do:
+14. For each :ref:`data segment <syntax-data>` :math:`\data_i` in :math:`\module.\MDATA` whose :ref:`mode <syntax-datamode>` :math:`\data_i.\DMODE` is of the form :math:`\DACTIVE~\{ \DMEM~\memidx_i, \DOFFSET~\X{doexpr}_i \}`, do:
 
     a. For each :ref:`byte <syntax-byte>` :math:`b_{ij}` in :math:`\data_i.\DINIT` (starting with :math:`j = 0`), do:
 

--- a/document/core/exec/runtime.rst
+++ b/document/core/exec/runtime.rst
@@ -314,7 +314,7 @@ Element Instances
 ~~~~~~~~~~~~~~~~~
 
 An *element instance* is the runtime representation of an :ref:`element segment <syntax-elem>`.
-Like table instances, an element instance holds a vector of function elements.
+It holds a vector of function elements.
 
 .. math::
   \begin{array}{llll}

--- a/document/core/syntax/modules.rst
+++ b/document/core/syntax/modules.rst
@@ -247,6 +247,7 @@ starting with the smallest index not referencing a global :ref:`import <syntax-i
    single: table; element
    single: element; segment
 .. _syntax-elem:
+.. _syntax-elemmode:
 .. _syntax-elemexpr:
 
 Element Segments
@@ -254,15 +255,20 @@ Element Segments
 
 The initial contents of a table is uninitialized. *Element segments* can be used to initialize a subrange of a table from a static :ref:`vector <syntax-vec>` of elements.
 
-Element segments can be :ref:`active <syntax-active>` or :ref:`passive <syntax-passive>`. An active element segment copies its elements into a table during :ref:`instantiation <exec-instantiation>`. A passive element segment's elements can be copied using the |TABLEINIT| instruction.
+The |MELEM| component of a module defines a vector of element segments.
+Each element segment defines an :ref:`element type <syntax-elemtype>` and a corresponding list of :ref:`element expressions <syntax-elemexpr>`.
 
-The |MELEM| component of a module defines a vector of element segments. Each active element segment defines the |ETABLE| and the starting |EOFFSET| in that table to initialize. Each passive element segment defines its element type and contents.
+Element segments have a mode that identifies them as either :ref:`passive <syntax-passive>` or :ref:`active <syntax-active>`.
+A passive element segment's elements can be copied to a table using the |TABLEINIT| instruction.
+An active element segment copies its elements into a table during :ref:`instantiation <exec-instantiation>`, as specified by a :ref:`table index <syntax-tableidx>` and a :ref:`constant <valid-constant>` :ref:`expression <syntax-expr>` defining an offset into that table.
 
 .. math::
    \begin{array}{llll}
    \production{element segment} & \elem &::=&
-     \{ \ETABLE~\tableidx, \EOFFSET~\expr, \ETYPE~\elemtype, \EINIT~\vec(\elemexpr) \} \\&&|&
-     \{ \ETYPE~\elemtype, \EINIT~\vec(\elemexpr) \} \\
+     \{ \ETYPE~\elemtype, \EINIT~\vec(\elemexpr), \EMODE~\elemmode \} \\
+   \production{element segment mode} & \elemmode &::=&
+     \EPASSIVE \\&&|&
+     \EACTIVE~\{ \ETABLE~\tableidx, \EOFFSET~\expr \} \\
    \production{elemexpr} & \elemexpr &::=&
      \REFNULL~\END \\&&|&
      (\REFFUNC~\funcidx)~\END \\
@@ -282,24 +288,27 @@ Element segments are referenced through :ref:`element indices <syntax-elemidx>`.
    single: memory; data
    single: data; segment
 .. _syntax-data:
+.. _syntax-datamode:
 
 Data Segments
 ~~~~~~~~~~~~~
 
 The initial contents of a :ref:`memory <syntax-mem>` are zero bytes. *Data segments* can be used to initialize a range of memory from a static :ref:`vector <syntax-vec>` of :ref:`bytes <syntax-byte>`.
 
-Like element segments, data segments can be :ref:`active <syntax-active>` or :ref:`passive <syntax-passive>`. An active data segment copies its contents into a table during :ref:`instantiation <exec-instantiation>`. A passive data segment's contents can be copied using the |MEMORYINIT| instruction.
+The |MDATA| component of a module defines a vector of data segments.
 
-The |MDATA| component of a module defines a vector of data segments. Each active data segment defines the memory to initialize, and the starting |DOFFSET| in that memory to initialize. Each passive data segment only defines its contents.
+Like element segments, data segments have a mode that identifies them as either :ref:`passive <syntax-passive>` or :ref:`active <syntax-active>`.
+A passive data segment's contents can be copied into a memory using the |MEMORYINIT| instruction.
+An active data segment copies its contents into a memory during :ref:`instantiation <exec-instantiation>`, as specified by a :ref:`memory index <syntax-memidx>` and a :ref:`constant <valid-constant>` :ref:`expression <syntax-expr>` defining an offset into that memory.
 
 .. math::
    \begin{array}{llll}
    \production{data segment} & \data &::=&
-     \{ \DMEM~\memidx, \DOFFSET~\expr, \DINIT~\vec(\byte) \} \\&&|&
-     \{ \DINIT~\vec(\byte) \} \\
+     \{ \DINIT~\vec(\byte), \DMODE~\datamode \} \\
+   \production{data segment mode} & \datamode &::=&
+     \DPASSIVE \\&&|&
+     \DACTIVE~\{ \DMEM~\memidx, \DOFFSET~\expr \} \\
    \end{array}
-
-The |DOFFSET| is given by a :ref:`constant <valid-constant>` :ref:`expression <syntax-expr>`.
 
 Data segments are referenced through :ref:`data indices <syntax-dataidx>`.
 

--- a/document/core/syntax/types.rst
+++ b/document/core/syntax/types.rst
@@ -190,13 +190,13 @@ Global Types
 Segment Types
 ~~~~~~~~~~~~~
 
-*Segment types* classify :ref:`data segments <syntax-data>` and :ref:`element segments <syntax-elem>`, which can either be *active* or *passive*.
+*Segment types* classify :ref:`data segments <syntax-data>` and :ref:`element segments <syntax-elem>`, which can either be  *passive* or *active*.
 
 .. math::
    \begin{array}{llll}
    \production{segment type} & \segtype &::=&
-     \SACTIVE ~|~
-     \SPASSIVE \\
+     \SPASSIVE ~|~
+     \SACTIVE \\
    \end{array}
 
 

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -500,7 +500,7 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
      \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~(et, y^\ast){:}\Telemlist~\text{)} \\ &&& \qquad
        \Rightarrow\quad \{ \ETYPE~et, \EINIT~y^\ast, \EMODE~\EACTIVE~\{ \ETABLE~x, \EOFFSET~e \} \} \\
    \production{element list} & \Telemlist &::=&
-     et{:}\Telemtype~~y^\ast{:}\Tvec(\Telemexpr_I) \qquad\Rightarrow\quad ( \ETYPE~et, \EINIT~y^\ast ) \\ &&|&
+     et{:}\Telemtype~~y^\ast{:}\Tvec(\Telemexpr_I) \qquad\Rightarrow\quad ( \ETYPE~et, \EINIT~y^\ast ) \\
    \production{element expression} & \Telemexpr &::=&
      \text{(}~\text{ref.null}~\text{)} \\ &&|&
      \text{(}~\text{ref.func}~~\Tfuncidx_I~\text{)} \\
@@ -536,13 +536,13 @@ Also, the table index can be omitted, defaulting to :math:`\T{0}`.
 Furthermore, for backwards compatibility with earlier versions of WebAssembly, if the table index is omitted, the :math:`\text{func}` keyword can be omitted as well.
 
 .. math::
-   \begin{array}{llclll}
+   \begin{array}{ll}
    \production{element segment} &
     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Telemlist~\text{)}
-       &\equiv&
-     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Telemlist~\text{)}
+       \quad\equiv \\&
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Telemlist~\text{)} \\
     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Tvec(\Tfuncidx_I)~\text{)}
-       &\equiv&
+       \quad\equiv \\&
      \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\text{func}~~\Tvec(\Tfuncidx_I)~\text{)}
    \end{array}
 

--- a/document/core/text/modules.rst
+++ b/document/core/text/modules.rst
@@ -286,9 +286,9 @@ An :ref:`element segment <text-elem>` can be given inline with a table definitio
 .. math::
    \begin{array}{llclll}
    \production{module field} &
-     \text{(}~\text{table}~~\Tid^?~~\Telemtype~~\text{(}~\text{elem}~~x^n{:}\Tvec(\Tfuncidx)~\text{)}~~\text{)} \quad\equiv \\ & \qquad
+     \text{(}~\text{table}~~\Tid^?~~\Telemtype~~\text{(}~\text{elem}~~\Telemlist~\text{)} \quad\equiv \\ & \qquad
        \text{(}~\text{table}~~\Tid'~~n~~n~~\Telemtype~\text{)}~~
-       \text{(}~\text{elem}~~\Tid'~~\text{(}~\text{i32.const}~~\text{0}~\text{)}~~\Tvec(\Tfuncidx)~\text{)}
+       \text{(}~\text{elem}~~\text{(}~\text{table}~~\Tid'~\text{)}~~\text{(}~\text{i32.const}~~\text{0}~\text{)}~~\Telemlist~\text{)}
        \\ & \qquad\qquad
        (\iff \Tid' = \Tid^? \neq \epsilon \vee \Tid' \idfresh) \\
    \end{array}
@@ -357,7 +357,7 @@ A :ref:`data segment <text-data>` can be given inline with a memory definition, 
    \production{module field} &
      \text{(}~\text{memory}~~\Tid^?~~\text{(}~\text{data}~~b^n{:}\Tdatastring~\text{)}~~\text{)} \quad\equiv \\ & \qquad
        \text{(}~\text{memory}~~\Tid'~~m~~m~\text{)}~~
-       \text{(}~\text{data}~~\Tid'~~\text{(}~\text{i32.const}~~\text{0}~\text{)}~~\Tdatastring~\text{)}
+       \text{(}~\text{data}~~\text{(}~\text{memory}~~\Tid'~\text{)}~~\text{(}~\text{i32.const}~~\text{0}~\text{)}~~\Tdatastring~\text{)}
        \\ & \qquad\qquad
        (\iff \Tid' = \Tid^? \neq \epsilon \vee \Tid' \idfresh, m = \F{ceil}(n / 64\F{Ki})) \\
    \end{array}
@@ -484,6 +484,8 @@ A :ref:`start function <syntax-start>` is defined in terms of its index.
    single: table; element
    single: element; segment
 .. _text-elem:
+.. _text-elemlist:
+.. _text-elemexpr:
 
 Element Segments
 ~~~~~~~~~~~~~~~~
@@ -493,13 +495,15 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
 .. math::
    \begin{array}{llclll}
    \production{element segment} & \Telem_I &::=&
-     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~(et, y^\ast){:}\Telemlist~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \ETABLE~x, \EOFFSET~e, \ETYPE~et, \EINIT~y^\ast \} \\ &&|&
      \text{(}~\text{elem}~~\Tid^?~~(et, y^\ast){:}\Telemlist~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{\ETYPE~et,\EINIT~y^\ast \} \\
-   \production{elemlist}  & \Telemlist &::=&
-     \text{func}~~y^\ast{:}\Tvec(\Tfuncidx_I) \qquad\Rightarrow\quad ( \ETYPE~\FUNCREF, \EINIT~y^\ast ) \\ &&|&
-     et{:}\Telemtype~~y^\ast{:}\Tvec(\Texpr_I) \qquad\Rightarrow\quad ( \ETYPE~et, \EINIT~y^\ast ) \\
+       \Rightarrow\quad \{ \ETYPE~et, \EINIT~y^\ast, \EMODE~\EPASSIVE \} \\ &&|&
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~x{:}\Ttableidx_I ~\text{)}~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~(et, y^\ast){:}\Telemlist~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \ETYPE~et, \EINIT~y^\ast, \EMODE~\EACTIVE~\{ \ETABLE~x, \EOFFSET~e \} \} \\
+   \production{element list} & \Telemlist &::=&
+     et{:}\Telemtype~~y^\ast{:}\Tvec(\Telemexpr_I) \qquad\Rightarrow\quad ( \ETYPE~et, \EINIT~y^\ast ) \\ &&|&
+   \production{element expression} & \Telemexpr &::=&
+     \text{(}~\text{ref.null}~\text{)} \\ &&|&
+     \text{(}~\text{ref.func}~~\Tfuncidx_I~\text{)} \\
    \end{array}
 
 .. note::
@@ -510,7 +514,7 @@ Element segments allow for an optional :ref:`table index <text-tableidx>` to ide
 Abbreviations
 .............
 
-As an abbreviation, a single instruction may occur in place of the offset:
+As an abbreviation, a single instruction may occur in place of the offset of an active element segment:
 
 .. math::
    \begin{array}{llcll}
@@ -519,14 +523,27 @@ As an abbreviation, a single instruction may occur in place of the offset:
      \text{(}~\text{offset}~~\Tinstr~\text{)}
    \end{array}
 
-Also, the table index can be omitted, defaulting to :math:`\T{0}`. If the table index is omitted, also the :math:`\text{func}` keyword can be omitted.
+Also, the element list may be written as just a sequence of :ref:`function indices <text-funcidx>`:
+
+.. math::
+   \begin{array}{llcll}
+   \production{element list} &
+     \text{func}~~\Tvec(\Tfuncidx_I) &\equiv&
+     \text{funcref}~~\Tvec(\text{(}~\text{ref.func}~~\Tfuncidx_I~\text{)})
+   \end{array}
+
+Also, the table index can be omitted, defaulting to :math:`\T{0}`.
+Furthermore, for backwards compatibility with earlier versions of WebAssembly, if the table index is omitted, the :math:`\text{func}` keyword can be omitted as well.
 
 .. math::
    \begin{array}{llclll}
    \production{element segment} &
-    \text{(}~\text{elem}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
+    \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Telemlist~\text{)}
        &\equiv&
-     \text{(}~\text{elem}~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Telemlist~\text{)}
+    \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\Tvec(\Tfuncidx_I)~\text{)}
+       &\equiv&
+     \text{(}~\text{elem}~~\Tid^?~~\text{(}~\text{table}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\text{func}~~\Tvec(\Tfuncidx_I)~\text{)}
    \end{array}
 
 As another abbreviation, element segments may also be specified inline with :ref:`table <text-table>` definitions; see the respective section.
@@ -548,10 +565,10 @@ The data is written as a :ref:`string <text-string>`, which may be split up into
 .. math::
    \begin{array}{llclll}
    \production{data segment} & \Tdata_I &::=&
-     \text{(}~\text{data}~~\Tid^?~~x{:}\Tmemidx_I~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~b^\ast{:}\Tdatastring~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \DMEM~x', \DOFFSET~e, \DINIT~b^\ast \} \\ &&|&
-     \text{(}~\text{data}~~\Tid^?~~\text{passive}~~b^\ast{:}\Tdatastring~\text{)} \\ &&& \qquad
-       \Rightarrow\quad \{ \DINIT~b^\ast \} \\
+     \text{(}~\text{data}~~\Tid^?~~b^\ast{:}\Tdatastring~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \DINIT~b^\ast, \DMODE~\DPASSIVE \} \\ &&|&
+     \text{(}~\text{data}~~\Tid^?~~\text{(}~\text{memory}~~x{:}\Tmemidx_I ~\text{)}~~\text{(}~\text{offset}~~e{:}\Texpr_I~\text{)}~~b^\ast{:}\Tdatastring~\text{)} \\ &&& \qquad
+       \Rightarrow\quad \{ \DINIT~b^\ast, \DMODE~\DACTIVE~\{ \DMEM~x', \DOFFSET~e \} \} \\
    \production{data string} & \Tdatastring &::=&
      (b^\ast{:}\Tstring)^\ast \quad\Rightarrow\quad \concat((b^\ast)^\ast) \\
    \end{array}
@@ -564,7 +581,7 @@ The data is written as a :ref:`string <text-string>`, which may be split up into
 Abbreviations
 .............
 
-As an abbreviation, a single instruction may occur in place of the offset:
+As an abbreviation, a single instruction may occur in place of the offset of an active data segment:
 
 .. math::
    \begin{array}{llcll}
@@ -578,9 +595,9 @@ Also, the memory index can be omitted, defaulting to :math:`\T{0}`.
 .. math::
    \begin{array}{llclll}
    \production{data segment} &
-    \text{(}~\text{data}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
+    \text{(}~\text{data}~~\Tid^?~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
        &\equiv&
-     \text{(}~\text{data}~~0~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
+     \text{(}~\text{data}~~\Tid^?~~\text{(}~\text{memory}~~\text{0}~\text{)}~~\text{(}~\text{offset}~~\Texpr_I~\text{)}~~\dots~\text{)}
    \end{array}
 
 As another abbreviation, data segments may also be specified inline with :ref:`memory <text-mem>` definitions; see the respective section.

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -263,17 +263,23 @@
 .. |GTYPE| mathdef:: \xref{syntax/modules}{syntax-global}{\K{type}}
 .. |GINIT| mathdef:: \xref{syntax/modules}{syntax-global}{\K{init}}
 
+.. |ETYPE| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{type}}
+.. |EINIT| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{init}}
+.. |EMODE| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{mode}}
+.. |EPASSIVE| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{passive}}
+.. |EACTIVE| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{active}}
 .. |ETABLE| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{table}}
 .. |EOFFSET| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{offset}}
-.. |EINIT| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{init}}
-.. |ETYPE| mathdef:: \xref{syntax/modules}{syntax-elem}{\K{type}}
 
 .. |REFNULL| mathdef:: \xref{syntax/modules}{syntax-elemexpr}{\K{ref.null}}
 .. |REFFUNC| mathdef:: \xref{syntax/modules}{syntax-elemexpr}{\K{ref.func}}
 
+.. |DINIT| mathdef:: \xref{syntax/modules}{syntax-data}{\K{init}}
+.. |DMODE| mathdef:: \xref{syntax/modules}{syntax-data}{\K{mode}}
+.. |DPASSIVE| mathdef:: \xref{syntax/modules}{syntax-data}{\K{passive}}
+.. |DACTIVE| mathdef:: \xref{syntax/modules}{syntax-data}{\K{active}}
 .. |DMEM| mathdef:: \xref{syntax/modules}{syntax-data}{\K{data}}
 .. |DOFFSET| mathdef:: \xref{syntax/modules}{syntax-data}{\K{offset}}
-.. |DINIT| mathdef:: \xref{syntax/modules}{syntax-data}{\K{init}}
 
 .. |SFUNC| mathdef:: \xref{syntax/modules}{syntax-start}{\K{func}}
 
@@ -306,8 +312,10 @@
 .. |importdesc| mathdef:: \xref{syntax/modules}{syntax-importdesc}{\X{importdesc}}
 .. |exportdesc| mathdef:: \xref{syntax/modules}{syntax-exportdesc}{\X{exportdesc}}
 .. |elem| mathdef:: \xref{syntax/modules}{syntax-elem}{\X{elem}}
+.. |elemmode| mathdef:: \xref{syntax/modules}{syntax-elemmode}{\X{elemmode}}
 .. |elemexpr| mathdef:: \xref{syntax/modules}{syntax-elemexpr}{\X{elemexpr}}
 .. |data| mathdef:: \xref{syntax/modules}{syntax-data}{\X{data}}
+.. |datamode| mathdef:: \xref{syntax/modules}{syntax-datamode}{\X{datamode}}
 .. |start| mathdef:: \xref{syntax/modules}{syntax-start}{\X{start}}
 
 
@@ -690,6 +698,8 @@
 .. |Timportdesc| mathdef:: \xref{text/modules}{text-importdesc}{\T{importdesc}}
 .. |Texportdesc| mathdef:: \xref{text/modules}{text-exportdesc}{\T{exportdesc}}
 .. |Telem| mathdef:: \xref{text/modules}{text-elem}{\T{elem}}
+.. |Telemlist| mathdef:: \xref{text/modules}{text-elemlist}{\T{elemlist}}
+.. |Telemexpr| mathdef:: \xref{text/modules}{text-elemexpr}{\X{elemexpr}}
 .. |Tcode| mathdef:: \xref{text/modules}{text-code}{\T{code}}
 .. |Tlocal| mathdef:: \xref{text/modules}{text-local}{\T{local}}
 .. |Tlocals| mathdef:: \xref{text/modules}{text-local}{\T{locals}}
@@ -703,7 +713,6 @@
 .. |Tmemarg| mathdef:: \xref{text/instructions}{text-memarg}{\T{memarg}}
 .. |Talign| mathdef:: \xref{text/instructions}{text-memarg}{\T{align}}
 .. |Toffset| mathdef:: \xref{text/instructions}{text-memarg}{\T{offset}}
-.. |Telemlist| mathdef:: \xref{text/instructions}{text-memarg}{\T{elemlist}}
 
 .. |Tlabel| mathdef:: \xref{text/instructions}{text-label}{\T{label}}
 .. |Tinstr| mathdef:: \xref{text/instructions}{text-instr}{\T{instr}}
@@ -781,8 +790,10 @@
 .. |vdashmem| mathdef:: \xref{valid/modules}{valid-mem}{\vdash}
 .. |vdashglobal| mathdef:: \xref{valid/modules}{valid-global}{\vdash}
 .. |vdashelem| mathdef:: \xref{valid/modules}{valid-elem}{\vdash}
+.. |vdashelemmode| mathdef:: \xref{valid/modules}{valid-elemmode}{\vdash}
 .. |vdashelemexpr| mathdef:: \xref{valid/modules}{valid-elemexpr}{\vdash}
 .. |vdashdata| mathdef:: \xref{valid/modules}{valid-data}{\vdash}
+.. |vdashdatamode| mathdef:: \xref{valid/modules}{valid-datamode}{\vdash}
 .. |vdashstart| mathdef:: \xref{valid/modules}{valid-start}{\vdash}
 .. |vdashexport| mathdef:: \xref{valid/modules}{valid-export}{\vdash}
 .. |vdashexportdesc| mathdef:: \xref{valid/modules}{valid-exportdesc}{\vdash}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -534,6 +534,7 @@
 .. |Bimportdesc| mathdef:: \xref{binary/modules}{binary-importdesc}{\B{importdesc}}
 .. |Bexportdesc| mathdef:: \xref{binary/modules}{binary-exportdesc}{\B{exportdesc}}
 .. |Belem| mathdef:: \xref{binary/modules}{binary-elem}{\B{elem}}
+.. |Belemkind| mathdef:: \xref{binary/modules}{binary-elemexpr}{\B{elemkind}}
 .. |Belemexpr| mathdef:: \xref{binary/modules}{binary-elemexpr}{\B{elemexpr}}
 .. |Bcode| mathdef:: \xref{binary/modules}{binary-code}{\B{code}}
 .. |Blocal| mathdef:: \xref{binary/modules}{binary-local}{\B{local}}

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -278,7 +278,7 @@
 .. |DMODE| mathdef:: \xref{syntax/modules}{syntax-data}{\K{mode}}
 .. |DPASSIVE| mathdef:: \xref{syntax/modules}{syntax-data}{\K{passive}}
 .. |DACTIVE| mathdef:: \xref{syntax/modules}{syntax-data}{\K{active}}
-.. |DMEM| mathdef:: \xref{syntax/modules}{syntax-data}{\K{data}}
+.. |DMEM| mathdef:: \xref{syntax/modules}{syntax-data}{\K{memory}}
 .. |DOFFSET| mathdef:: \xref{syntax/modules}{syntax-data}{\K{offset}}
 
 .. |SFUNC| mathdef:: \xref{syntax/modules}{syntax-start}{\K{func}}

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -251,7 +251,7 @@ Data segments :math:`\data` are classified by :ref:`segment types <syntax-segtyp
 :math:`\{ \DINIT~b^\ast, \DMODE~\datamode \}`
 ....................................................
 
-* The data mode :math:`\elemmode` must valid with type :math:`\segtype`.
+* The data mode :math:`\datamode` must valid with type :math:`\segtype`.
 
 * Then the data segment is valid with type :math:`\segtype`.
 

--- a/document/core/valid/modules.rst
+++ b/document/core/valid/modules.rst
@@ -145,65 +145,27 @@ Globals :math:`\global` are classified by :ref:`global types <syntax-globaltype>
 Element Segments
 ~~~~~~~~~~~~~~~~
 
-Element segments :math:`\elem` are classified by :ref:`segment types <syntax-segtype>`.
+Element segments :math:`\elem` are classified by :ref:`segment types <syntax-segtype>`, as determined by their :ref:`mode <syntax-elemmode>`.
 
-:math:`\{ \ETABLE~x, \EOFFSET~\expr, \ETYPE~et, \EINIT~e^\ast \}`
-.................................................................
-
-* The table :math:`C.\CTABLES[x]` must be defined in the context.
-
-* Let :math:`\limits~\elemtype` be the :ref:`table type <syntax-tabletype>` :math:`C.\CTABLES[x]`.
-
-* The :ref:`element type <syntax-elemtype>` :math:`\elemtype` must be |FUNCREF|.
-
-* The expression :math:`\expr` must be :ref:`valid <valid-expr>` with :ref:`result type <syntax-resulttype>` :math:`[\I32]`.
-
-* The expression :math:`\expr` must be :ref:`constant <valid-constant>`.
-
-* The :ref:`element type <syntax-elemtype>` :math:`et` must be |FUNCREF|.
+:math:`\{ \ETYPE~et, \EINIT~e^\ast, \EMODE~\elemmode \}`
+........................................................
 
 * For each :math:`e_i` in :math:`e^\ast`,
 
   * The element expression :math:`e_i` must be :ref:`valid <valid-elemexpr>`.
 
-* Then the element segment is valid with type |SACTIVE|.
+* The element mode :math:`\elemmode` must valid with type :math:`\segtype`.
+
+* Then the element segment is valid with type :math:`\segtype`.
 
 
 .. math::
    \frac{
-     C.\CTABLES[x] = \limits~\FUNCREF
-     \qquad
-     C \vdashexpr \expr : [\I32]
-     \qquad
-     C \vdashexprconst \expr \const
-     \qquad
-     et = \FUNCREF
-     \qquad
      (C \vdashelemexpr e \ok)^\ast
-   }{
-     C \vdashelem \{ \ETABLE~x, \EOFFSET~\expr, \ETYPE~et, \EINIT~e^\ast \} : \SACTIVE
-   }
-
-
-:math:`\{ \ETYPE~et, \EINIT~e^\ast \}`
-......................................
-
-* The :ref:`element type <syntax-elemtype>` :math:`et` must be |FUNCREF|.
-
-* For each :math:`e_i` in :math:`e^\ast`,
-
-  * The element expression :math:`e_i` must be :ref:`valid <valid-elemexpr>`.
-
-* Then the element segment is valid with type |SPASSIVE|.
-
-
-.. math::
-   \frac{
-     et = \FUNCREF
      \qquad
-     (C \vdashelemexpr e \ok)^\ast
+     C; \X{et} \vdashelemmode \elemmode : \segtype
    }{
-     C \vdashelem \{ \ETYPE~et, \EINIT~e^\ast \} : \SPASSIVE
+     C \vdashelem \{ \ETYPE~et, \EINIT~e^\ast, \EMODE~\elemmode \} : \segtype
    }
 
 
@@ -231,6 +193,49 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
    }
 
 
+.. _valid-elemmode:
+
+:math:`\EPASSIVE`
+.................
+
+* The element mode is valid with type |SPASSIVE|.
+
+.. math::
+   \frac{
+   }{
+     C; \X{et} \vdashelemmode \EPASSIVE : \SPASSIVE
+   }
+
+
+:math:`\EACTIVE~\{ \ETABLE~x, \EOFFSET~\expr \}`
+................................................
+
+* The table :math:`C.\CTABLES[x]` must be defined in the context.
+
+* Let :math:`\limits~\elemtype` be the :ref:`table type <syntax-tabletype>` :math:`C.\CTABLES[x]`.
+
+* The :ref:`element type <syntax-elemtype>` :math:`\X{et}` of the segment must match :math:`\elemtype`.
+
+* The expression :math:`\expr` must be :ref:`valid <valid-expr>` with :ref:`result type <syntax-resulttype>` :math:`[\I32]`.
+
+* The expression :math:`\expr` must be :ref:`constant <valid-constant>`.
+
+* Then the element mode is valid with type |SACTIVE|.
+
+.. math::
+   \frac{
+     C.\CTABLES[x] = \limits~\elemtype
+     \qquad
+     \X{et} = \elemtype
+     \qquad
+     C \vdashexpr \expr : [\I32]
+     \qquad
+     C \vdashexprconst \expr \const
+   }{
+     C; \X{et} \vdashelemmode \EACTIVE~\{ \ETABLE~x, \EOFFSET~\expr \} : \SACTIVE
+   }
+
+
 .. index:: data, memory, memory index, expression, byte
    pair: validation; data
    single: abstract syntax; data
@@ -241,10 +246,39 @@ Element segments :math:`\elem` are classified by :ref:`segment types <syntax-seg
 Data Segments
 ~~~~~~~~~~~~~
 
-Data segments :math:`\data` are classified by :ref:`segment types <syntax-segtype>`.
+Data segments :math:`\data` are classified by :ref:`segment types <syntax-segtype>`, as determined by their :ref:`mode <syntax-datamode>`.
 
-:math:`\{ \DMEM~x, \DOFFSET~\expr, \DINIT~b^\ast \}`
+:math:`\{ \DINIT~b^\ast, \DMODE~\datamode \}`
 ....................................................
+
+* The data mode :math:`\elemmode` must valid with type :math:`\segtype`.
+
+* Then the data segment is valid with type :math:`\segtype`.
+
+.. math::
+   \frac{
+     C \vdashdatamode \datamode : \segtype
+   }{
+     C \vdashdata \{ \DINIT~b^\ast, \DMODE~\datamode \} : \segtype
+   }
+
+
+.. _valid-datamode:
+
+:math:`\DPASSIVE`
+.................
+
+* The data mode is valid with type |SPASSIVE|.
+
+.. math::
+   \frac{
+   }{
+     C \vdashdatamode \DPASSIVE : \SPASSIVE
+   }
+
+
+:math:`\DACTIVE~\{ \DMEM~x, \DOFFSET~\expr \}`
+..............................................
 
 * The memory :math:`C.\CMEMS[x]` must be defined in the context.
 
@@ -252,8 +286,7 @@ Data segments :math:`\data` are classified by :ref:`segment types <syntax-segtyp
 
 * The expression :math:`\expr` must be :ref:`constant <valid-constant>`.
 
-* Then the data segment is valid with type |SACTIVE|.
-
+* Then the data mode is valid with type |SACTIVE|.
 
 .. math::
    \frac{
@@ -263,20 +296,7 @@ Data segments :math:`\data` are classified by :ref:`segment types <syntax-segtyp
      \qquad
      C \vdashexprconst \expr \const
    }{
-     C \vdashdata \{ \DMEM~x, \DOFFSET~\expr, \DINIT~b^\ast \} : \SACTIVE
-   }
-
-
-:math:`\{ \DINIT~b^\ast \}`
-....................................................
-
-* The data segment is valid.
-
-
-.. math::
-   \frac{
-   }{
-     C \vdashdata \{ \DINIT~b^\ast \} : \SPASSIVE
+     C \vdashelemmode \EACTIVE~\{ \DMEM~x, \DOFFSET~\expr \} : \SACTIVE
    }
 
 

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -557,8 +557,8 @@ let memory_section s =
 
 let global s =
   let gtype = global_type s in
-  let value = const s in
-  {gtype; value}
+  let ginit = const s in
+  {gtype; ginit}
 
 let global_section s =
   section `GlobalSection (vec (at global)) [] s
@@ -647,32 +647,32 @@ let elem s =
   match vu32 s with
   | 0x00l ->
     let emode = at active_zero s in
-    let elems = vec (at elem_index) s in
-    {etype = FuncRefType; elems; emode}
+    let einit = vec (at elem_index) s in
+    {etype = FuncRefType; einit; emode}
   | 0x01l ->
     let emode = at passive s in
     let etype = elem_kind s in
-    let elems = vec (at elem_index) s in
-    {etype; elems; emode}
+    let einit = vec (at elem_index) s in
+    {etype; einit; emode}
   | 0x02l ->
     let emode = at active s in
     let etype = elem_kind s in
-    let elems = vec (at elem_index) s in
-    {etype; elems; emode}
+    let einit = vec (at elem_index) s in
+    {etype; einit; emode}
   | 0x04l ->
     let emode = at active_zero s in
-    let elems = vec (at elem_expr) s in
-    {etype = FuncRefType; elems; emode}
+    let einit = vec (at elem_expr) s in
+    {etype = FuncRefType; einit; emode}
   | 0x05l ->
     let emode = at passive s in
     let etype = elem_type s in
-    let elems = vec (at elem_expr) s in
-    {etype; elems; emode}
+    let einit = vec (at elem_expr) s in
+    {etype; einit; emode}
   | 0x06l ->
     let emode = at active s in
     let etype = elem_type s in
-    let elems = vec (at elem_expr) s in
-    {etype; elems; emode}
+    let einit = vec (at elem_expr) s in
+    {etype; einit; emode}
   | _ -> error s (pos s - 1) "invalid elements segment kind"
 
 let elem_section s =
@@ -685,16 +685,16 @@ let data s =
   match vu32 s with
   | 0x00l ->
     let dmode = at active_zero s in
-    let data = string s in
-    {data; dmode}
+    let dinit = string s in
+    {dinit; dmode}
   | 0x01l ->
     let dmode = at passive s in
-    let data = string s in
-    {data; dmode}
+    let dinit = string s in
+    {dinit; dmode}
   | 0x02l ->
     let dmode = at active s in
-    let data = string s in
-    {data; dmode}
+    let dinit = string s in
+    {dinit; dmode}
   | _ -> error s (pos s - 1) "invalid data segment kind"
 
 let data_section s =

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -643,41 +643,35 @@ let elem_expr s =
     ref_func x
   | _ -> error s (pos s - 1) "invalid element expression"
 
-let elem_indices s =
-  vec (at elem_index) s
-
-let elem_exprs s =
-  vec (at elem_expr) s
-
 let elem s =
-  match u8 s with
-  | 0x00 ->
+  match vu32 s with
+  | 0x00l ->
     let emode = at active_zero s in
-    let elems = elem_indices s in
+    let elems = vec (at elem_index) s in
     {etype = FuncRefType; elems; emode}
-  | 0x01 ->
+  | 0x01l ->
     let emode = at passive s in
     let etype = elem_kind s in
-    let elems = elem_indices s in
+    let elems = vec (at elem_index) s in
     {etype; elems; emode}
-  | 0x02 ->
+  | 0x02l ->
     let emode = at active s in
     let etype = elem_kind s in
-    let elems = elem_indices s in
+    let elems = vec (at elem_index) s in
     {etype; elems; emode}
-  | 0x04 ->
+  | 0x04l ->
     let emode = at active_zero s in
-    let elems = elem_exprs s in
+    let elems = vec (at elem_expr) s in
     {etype = FuncRefType; elems; emode}
-  | 0x05 ->
+  | 0x05l ->
     let emode = at passive s in
     let etype = elem_type s in
-    let elems = elem_exprs s in
+    let elems = vec (at elem_expr) s in
     {etype; elems; emode}
-  | 0x06 ->
+  | 0x06l ->
     let emode = at active s in
     let etype = elem_type s in
-    let elems = elem_exprs s in
+    let elems = vec (at elem_expr) s in
     {etype; elems; emode}
   | _ -> error s (pos s - 1) "invalid elements segment kind"
 
@@ -689,15 +683,15 @@ let elem_section s =
 
 let data s =
   match vu32 s with
-  | 0l ->
+  | 0x00l ->
     let dmode = at active_zero s in
     let data = string s in
     {data; dmode}
-  | 1l ->
+  | 0x01l ->
     let dmode = at passive s in
     let data = string s in
     {data; dmode}
-  | 2l ->
+  | 0x02l ->
     let dmode = at active s in
     let data = string s in
     {data; dmode}

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -630,7 +630,7 @@ let elem_index s =
   ref_func (at var s)
 
 let elem_kind s =
-  match vs7 s with
+  match u8 s with
   | 0x00 -> FuncRefType
   | _ -> error s (pos s - 1) "invalid element kind"
 

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -430,8 +430,8 @@ let encode m =
 
     (* Global section *)
     let global g =
-      let {gtype; value} = g.it in
-      global_type gtype; const value
+      let {gtype; ginit} = g.it in
+      global_type gtype; const ginit
 
     let global_section gs =
       section 6 (vec global) gs (gs <> [])
@@ -493,41 +493,41 @@ let encode m =
     let is_func_ref e = match e.it with RefFunc _ -> true | _ -> false
 
     let elem seg =
-      let {etype; elems; emode} = seg.it in
-      let has_indices = List.for_all is_func_ref elems in
+      let {etype; einit; emode} = seg.it in
+      let has_indices = List.for_all is_func_ref einit in
       match emode.it with
       | Passive ->
         if has_indices then
-          (vu32 0x01l; elem_kind etype; vec elem_index elems)
+          (vu32 0x01l; elem_kind etype; vec elem_index einit)
         else
-          (vu32 0x05l; elem_type etype; vec elem_expr elems)
+          (vu32 0x05l; elem_type etype; vec elem_expr einit)
       | Active {index; offset} ->
         match index.it = 0l, etype = FuncRefType, has_indices with
         | true, true, true ->
-          vu32 0x00l; const offset; vec elem_index elems
+          vu32 0x00l; const offset; vec elem_index einit
         | true, true, false ->
-          vu32 0x04l; const offset; vec elem_expr elems
+          vu32 0x04l; const offset; vec elem_expr einit
         | _, _, true ->
           vu32 0x02l;
-          var index; const offset; elem_kind etype; vec elem_index elems
+          var index; const offset; elem_kind etype; vec elem_index einit
         | _, _, false ->
           vu32 0x06l;
-          var index; const offset; elem_type etype; vec elem_expr elems
+          var index; const offset; elem_type etype; vec elem_expr einit
 
     let elem_section elems =
       section 9 (vec elem) elems (elems <> [])
 
     (* Data section *)
     let data seg =
-      let {data; dmode} = seg.it in
+      let {dinit; dmode} = seg.it in
       match dmode.it with
       | Passive ->
-        vu32 0x01l; string data
+        vu32 0x01l; string dinit
       | Active {index; offset} ->
         if index.it = 0l then
-          (vu32 0x00l; const offset; string data)
+          (vu32 0x00l; const offset; string dinit)
         else
-          (vu32 0x02l; var index; const offset; string data)
+          (vu32 0x02l; var index; const offset; string dinit)
 
     let data_section datas =
       section 11 (vec data) datas (datas <> [])

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -448,13 +448,13 @@ let elem_list inst init =
 
 let create_elem (inst : module_inst) (seg : table_segment) : elem_inst =
   match seg.it with
-  | ActiveElem _ -> ref None
   | PassiveElem {data; _} -> ref (Some (elem_list inst data))
+  | ActiveElem _ -> ref None
 
 let create_data (inst : module_inst) (seg : memory_segment) : data_inst =
   match seg.it with
+  | PassiveData {data; _} -> ref (Some data)
   | ActiveData _ -> ref None
-  | PassiveData {data} -> ref (Some data)
 
 
 let init_func (inst : module_inst) (func : func_inst) =
@@ -464,25 +464,25 @@ let init_func (inst : module_inst) (func : func_inst) =
 
 let init_table (inst : module_inst) (seg : table_segment) =
   match seg.it with
-  | ActiveElem {index; offset = const; init; _} ->
+  | PassiveElem _ -> ()
+  | ActiveElem {etype; data; index; offset = const} ->
     let tab = table inst index in
     let offset = i32 (eval_const inst const) const.at in
-    let elems = elem_list inst init in
+    let elems = elem_list inst data in
     let len = Int32.of_int (List.length elems) in
     (try Table.init tab elems offset 0l len
     with Table.Bounds -> Link.error seg.at "elements segment does not fit table")
-  | PassiveElem _ -> ()
 
 let init_memory (inst : module_inst) (seg : memory_segment) =
   match seg.it with
-  | ActiveData {index; offset = const; init} ->
+  | PassiveData _ -> ()
+  | ActiveData {data; index; offset = const} ->
     let mem = memory inst index in
     let offset' = i32 (eval_const inst const) const.at in
     let offset = I64_convert.extend_i32_u offset' in
-    let len = Int32.of_int (String.length init) in
-    (try Memory.init mem init offset 0L len
+    let len = Int32.of_int (String.length data) in
+    (try Memory.init mem data offset 0L len
     with Memory.Bounds -> Link.error seg.at "data segment does not fit memory")
-  | PassiveData _ -> ()
 
 
 let add_import (m : module_) (ext : extern) (im : import) (inst : module_inst)

--- a/interpreter/runtime/table.ml
+++ b/interpreter/runtime/table.ml
@@ -9,7 +9,7 @@ type elem += Uninitialized
 
 type table' = elem array
 type table =
-  {mutable content : table'; max : size option; elem_type : ref_type}
+  {mutable content : table'; max : size option; elem_type : elem_type}
 type t = table
 
 exception Bounds

--- a/interpreter/runtime/table.ml
+++ b/interpreter/runtime/table.ml
@@ -9,7 +9,7 @@ type elem += Uninitialized
 
 type table' = elem array
 type table =
-  {mutable content : table'; max : size option; elem_type : elem_type}
+  {mutable content : table'; max : size option; elem_type : ref_type}
 type t = table
 
 exception Bounds

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -140,21 +140,30 @@ and memory' =
   mtype : memory_type;
 }
 
+type segment_mode = segment_mode' Source.phrase
+and segment_mode' =
+  | Passive
+  | Active of {index : var; offset : const}
 
-type elem = elem' Source.phrase
-and elem' =
+type elem_expr = elem_expr' Source.phrase
+and elem_expr' =
   | RefNull
   | RefFunc of var
 
-type table_segment = table_segment' Source.phrase
-and table_segment' =
-  | PassiveElem of {etype : ref_type; data : elem list}
-  | ActiveElem of {etype : ref_type; data : elem list; index : var; offset : const}
+type elem_segment = elem_segment' Source.phrase
+and elem_segment' =
+{
+  etype : elem_type;
+  elems : elem_expr list;
+  emode : segment_mode;
+}
 
-type memory_segment = memory_segment' Source.phrase
-and memory_segment' =
-  | PassiveData of {data : string}
-  | ActiveData of {data : string; index : var; offset : const}
+type data_segment = data_segment' Source.phrase
+and data_segment' =
+{
+  data : string;
+  dmode : segment_mode;
+}
 
 
 (* Modules *)
@@ -199,8 +208,8 @@ and module_' =
   memories : memory list;
   funcs : func list;
   start : var option;
-  elems : table_segment list;
-  datas : memory_segment list;
+  elems : elem_segment list;
+  datas : data_segment list;
   imports : import list;
   exports : export list;
 }

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -114,7 +114,7 @@ type global = global' Source.phrase
 and global' =
 {
   gtype : global_type;
-  value : const;
+  ginit : const;
 }
 
 type func = func' Source.phrase
@@ -154,14 +154,14 @@ type elem_segment = elem_segment' Source.phrase
 and elem_segment' =
 {
   etype : elem_type;
-  elems : elem_expr list;
+  einit : elem_expr list;
   emode : segment_mode;
 }
 
 type data_segment = data_segment' Source.phrase
 and data_segment' =
 {
-  data : string;
+  dinit : string;
   dmode : segment_mode;
 }
 

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -140,21 +140,21 @@ and memory' =
   mtype : memory_type;
 }
 
+
 type elem = elem' Source.phrase
 and elem' =
   | RefNull
   | RefFunc of var
 
-
 type table_segment = table_segment' Source.phrase
 and table_segment' =
-  | ActiveElem of {index : var; offset : const; etype : elem_type; init : elem list}
-  | PassiveElem of {etype : elem_type; data : elem list}
+  | PassiveElem of {etype : ref_type; data : elem list}
+  | ActiveElem of {etype : ref_type; data : elem list; index : var; offset : const}
 
 type memory_segment = memory_segment' Source.phrase
 and memory_segment' =
-  | ActiveData of {index : var; offset : const; init : string}
   | PassiveData of {data : string}
+  | ActiveData of {data : string; index : var; offset : const}
 
 
 (* Modules *)

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -85,7 +85,7 @@ and block (es : instr list) =
 
 let const (c : const) = block c.it
 
-let global (g : global) = const g.it.value
+let global (g : global) = const g.it.ginit
 let func (f : func) = {(block f.it.body) with locals = Set.empty}
 let table (t : table) = empty
 let memory (m : memory) = empty
@@ -101,7 +101,7 @@ let elem_expr (e : elem_expr) =
   | RefFunc x -> funcs (var x)
 
 let elem (s : elem_segment) =
-  list elem_expr s.it.elems ++ segment_mode tables s.it.emode
+  list elem_expr s.it.einit ++ segment_mode tables s.it.emode
 
 let data (s : data_segment) =
   segment_mode memories s.it.dmode

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -90,21 +90,21 @@ let func (f : func) = {(block f.it.body) with locals = Set.empty}
 let table (t : table) = empty
 let memory (m : memory) = empty
 
-let elem (e : elem) =
+let segment_mode f (m : segment_mode) =
+  match m.it with
+  | Passive -> empty
+  | Active {index; offset} -> f (var index) ++ const offset
+
+let elem_expr (e : elem_expr) =
   match e.it with
   | RefNull -> empty
   | RefFunc x -> funcs (var x)
 
-let table_segment (s : table_segment) =
-  match s.it with
-  | PassiveElem {data; _} -> list elem data
-  | ActiveElem {data; index; offset; _} ->
-    list elem data ++ tables (var index) ++ const offset
+let elem (s : elem_segment) =
+  list elem_expr s.it.elems ++ segment_mode tables s.it.emode
 
-let memory_segment (s : memory_segment) =
-  match s.it with
-  | PassiveData _ -> empty
-  | ActiveData {index; offset; _} -> memories (var index) ++ const offset
+let data (s : data_segment) =
+  segment_mode memories s.it.dmode
 
 let type_ (t : type_) = empty
 
@@ -135,7 +135,7 @@ let module_ (m : module_) =
   list memory m.it.memories ++
   list func m.it.funcs ++
   start m.it.start ++
-  list table_segment m.it.elems ++
-  list memory_segment m.it.datas ++
+  list elem m.it.elems ++
+  list data m.it.datas ++
   list import m.it.imports ++
   list export m.it.exports

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -97,14 +97,14 @@ let elem (e : elem) =
 
 let table_segment (s : table_segment) =
   match s.it with
-  | ActiveElem {index; offset; init; _} ->
-    tables (var index) ++ const offset ++ list elem init
   | PassiveElem {data; _} -> list elem data
+  | ActiveElem {data; index; offset; _} ->
+    list elem data ++ tables (var index) ++ const offset
 
 let memory_segment (s : memory_segment) =
   match s.it with
-  | ActiveData {index; offset; init} -> memories (var index) ++ const offset
-  | PassiveData {data} -> empty
+  | PassiveData _ -> empty
+  | ActiveData {index; offset; _} -> memories (var index) ++ const offset
 
 let type_ (t : type_) = empty
 

--- a/interpreter/syntax/free.mli
+++ b/interpreter/syntax/free.mli
@@ -25,8 +25,8 @@ val global : Ast.global -> t
 val func : Ast.func -> t
 val table : Ast.table -> t
 val memory : Ast.memory -> t
-val table_segment : Ast.table_segment -> t
-val memory_segment : Ast.memory_segment -> t
+val elem : Ast.elem_segment -> t
+val data : Ast.data_segment -> t
 val export : Ast.export -> t
 val import : Ast.import -> t
 val start : Ast.var option -> t

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -10,7 +10,7 @@ type mutability = Immutable | Mutable
 type table_type = TableType of Int32.t limits * elem_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
-type segment_type = SegmentType
+type segment_type = PassiveType | ActiveType
 type extern_type =
   | ExternFuncType of func_type
   | ExternTableType of table_type

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -1,13 +1,13 @@
 (* Types *)
 
 type value_type = I32Type | I64Type | F32Type | F64Type
-type ref_type = FuncRefType
+type elem_type = FuncRefType
 type stack_type = value_type list
 type func_type = FuncType of stack_type * stack_type
 
 type 'a limits = {min : 'a; max : 'a option}
 type mutability = Immutable | Mutable
-type table_type = TableType of Int32.t limits * ref_type
+type table_type = TableType of Int32.t limits * elem_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
 type segment_type = SegmentType
@@ -79,7 +79,7 @@ let string_of_value_types = function
   | [t] -> string_of_value_type t
   | ts -> "[" ^ String.concat " " (List.map string_of_value_type ts) ^ "]"
 
-let string_of_ref_type = function
+let string_of_elem_type = function
   | FuncRefType -> "funcref"
 
 let string_of_limits {min; max} =
@@ -90,7 +90,7 @@ let string_of_memory_type = function
   | MemoryType lim -> string_of_limits lim
 
 let string_of_table_type = function
-  | TableType (lim, t) -> string_of_limits lim ^ " " ^ string_of_ref_type t
+  | TableType (lim, t) -> string_of_limits lim ^ " " ^ string_of_elem_type t
 
 let string_of_global_type = function
   | GlobalType (t, Immutable) -> string_of_value_type t

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -1,13 +1,13 @@
 (* Types *)
 
 type value_type = I32Type | I64Type | F32Type | F64Type
-type elem_type = FuncRefType
+type ref_type = FuncRefType
 type stack_type = value_type list
 type func_type = FuncType of stack_type * stack_type
 
 type 'a limits = {min : 'a; max : 'a option}
 type mutability = Immutable | Mutable
-type table_type = TableType of Int32.t limits * elem_type
+type table_type = TableType of Int32.t limits * ref_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
 type segment_type = SegmentType
@@ -79,7 +79,7 @@ let string_of_value_types = function
   | [t] -> string_of_value_type t
   | ts -> "[" ^ String.concat " " (List.map string_of_value_type ts) ^ "]"
 
-let string_of_elem_type = function
+let string_of_ref_type = function
   | FuncRefType -> "funcref"
 
 let string_of_limits {min; max} =
@@ -90,7 +90,7 @@ let string_of_memory_type = function
   | MemoryType lim -> string_of_limits lim
 
 let string_of_table_type = function
-  | TableType (lim, t) -> string_of_limits lim ^ " " ^ string_of_elem_type t
+  | TableType (lim, t) -> string_of_limits lim ^ " " ^ string_of_ref_type t
 
 let string_of_global_type = function
   | GlobalType (t, Immutable) -> string_of_value_type t

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -319,18 +319,18 @@ let segment_mode category mode =
 let is_func_ref e = match e.it with RefFunc _ -> true | _ -> false
 
 let elem seg =
-  let {etype; elems; emode} = seg.it in
+  let {etype; einit; emode} = seg.it in
   Node ("elem",
     segment_mode "table" emode @
-    if List.for_all is_func_ref elems then
-      atom elem_kind etype :: list elem_index elems
+    if List.for_all is_func_ref einit then
+      atom elem_kind etype :: list elem_index einit
     else
-      atom elem_type etype :: list elem_expr elems
+      atom elem_type etype :: list elem_expr einit
   )
 
 let data seg =
-  let {data; dmode} = seg.it in
-  Node ("data", segment_mode "memory" dmode @ break_bytes data)
+  let {dinit; dmode} = seg.it in
+  Node ("data", segment_mode "memory" dmode @ break_bytes dinit)
 
 
 (* Modules *)
@@ -364,8 +364,8 @@ let export ex =
   Node ("export", [atom name n; export_desc edesc])
 
 let global off i g =
-  let {gtype; value} = g.it in
-  Node ("global $" ^ nat (off + i), global_type gtype :: const value)
+  let {gtype; ginit} = g.it in
+  Node ("global $" ^ nat (off + i), global_type gtype :: const ginit)
 
 
 (* Modules *)

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -601,24 +601,24 @@ elem :
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      { etype = FuncRefType; elems = $5 c func;
+      { etype = FuncRefType; einit = $5 c func;
         emode = Active {index = 0l @@ at; offset = $4 c} @@ at} @@ at }
   | LPAR ELEM bind_var_opt elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      {etype = (fst $4); elems = (snd $4) c; emode = Passive @@ at} @@ at }
+      {etype = (fst $4); einit = (snd $4) c; emode = Passive @@ at} @@ at }
   | LPAR ELEM bind_var_opt table_use offset elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      { etype = (fst $6); elems = (snd $6) c;
+      { etype = (fst $6); einit = (snd $6) c;
         emode = Active {index = $4 c table; offset = $5 c} @@ at} @@ at }
   | LPAR ELEM bind_var_opt offset elem_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      { etype = (fst $5); elems = (snd $5) c;
+      { etype = (fst $5); einit = (snd $5) c;
         emode = Active {index = 0l @@ at; offset = $4 c} @@ at} @@ at }
 
 table :
@@ -641,42 +641,42 @@ table_fields :
   | elem_type LPAR ELEM elem_var_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
-      let elems = $4 c func in
-      let size = Lib.List32.length elems in
+      let einit = $4 c func in
+      let size = Lib.List32.length einit in
       let emode = Active {index = x; offset} @@ at in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [{etype = FuncRefType; elems; emode} @@ at],
+      [{etype = FuncRefType; einit; emode} @@ at],
       [], [] }
   | elem_type LPAR ELEM elem_expr elem_expr_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
-      let elems = (fun c -> $4 c :: $5 c) c in
-      let size = Lib.List32.length elems in
+      let einit = (fun c -> $4 c :: $5 c) c in
+      let size = Lib.List32.length einit in
       let emode = Active {index = x; offset} @@ at in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [{etype = FuncRefType; elems; emode} @@ at],
+      [{etype = FuncRefType; einit; emode} @@ at],
       [], [] }
 
 data :
   | LPAR DATA bind_var_opt string_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_data bind_data);
-      fun () -> {data = $4; dmode = Passive @@ at} @@ at }
+      fun () -> {dinit = $4; dmode = Passive @@ at} @@ at }
  | LPAR DATA bind_var var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (bind_data c $3);
      fun () ->
-     {data = $6; dmode = Active {index = $4 c memory; offset = $5 c} @@ at} @@ at }
+     {dinit = $6; dmode = Active {index = $4 c memory; offset = $5 c} @@ at} @@ at }
  | LPAR DATA var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (anon_data c);
      fun () ->
-     {data = $5; dmode = Active {index = $3 c memory; offset = $4 c} @@ at} @@ at }
+     {dinit = $5; dmode = Active {index = $3 c memory; offset = $4 c} @@ at} @@ at }
  | LPAR DATA offset string_list RPAR  /* Sugar */
    { let at = at () in
      fun c -> ignore (anon_data c);
      fun () ->
-     {data = $4; dmode = Active {index = 0l @@ at; offset = $3 c} @@ at} @@ at }
+     {dinit = $4; dmode = Active {index = 0l @@ at; offset = $3 c} @@ at} @@ at }
 
 memory :
   | LPAR MEMORY bind_var_opt memory_fields RPAR
@@ -700,7 +700,7 @@ memory_fields :
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
       let size = Int32.(div (add (of_int (String.length $3)) 65535l) 65536l) in
       [{mtype = MemoryType {min = size; max = Some size}} @@ at],
-      [{data = $3; dmode = Active {index = x; offset} @@ at} @@ at],
+      [{dinit = $3; dmode = Active {index = x; offset} @@ at} @@ at],
       [], [] }
 
 global :
@@ -711,7 +711,7 @@ global :
 
 global_fields :
   | global_type const_expr
-    { fun c x at -> [{gtype = $1; value = $2 c} @@ at], [], [] }
+    { fun c x at -> [{gtype = $1; ginit = $2 c} @@ at], [], [] }
   | inline_import global_type  /* Sugar */
     { fun c x at ->
       [],

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -601,8 +601,10 @@ elem :
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ActiveElem {index = 0l @@ at; offset = $4 c; etype = FuncRefType;
-                           init = $5 c func} @@ at }
+      ActiveElem {
+        etype = FuncRefType; data = $5 c func;
+        index = 0l @@ at; offset = $4 c
+      } @@ at }
   | LPAR ELEM bind_var_opt elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
@@ -611,13 +613,16 @@ elem :
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-        ActiveElem {index = $4 c table; offset = $5 c;
-                    etype = (fst $6); init = (snd $6) c} @@ at }
+      ActiveElem {
+        etype = (fst $6); data = (snd $6) c;
+        index = $4 c table; offset = $5 c} @@ at }
   | LPAR ELEM bind_var_opt offset elem_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> ActiveElem {index = 0l @@ at; offset = $4 c;
-                         etype = (fst $5); init = (snd $5) c} @@ at }
+      fun () ->
+      ActiveElem {
+        etype = (fst $5); data = (snd $5) c;
+        index = 0l @@ at; offset = $4 c} @@ at }
 
 table :
   | LPAR TABLE bind_var_opt table_fields RPAR
@@ -639,18 +644,18 @@ table_fields :
   | elem_type LPAR ELEM elem_var_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
-      let init = $4 c func in
-      let size = Lib.List32.length init in
+      let data = $4 c func in
+      let size = Lib.List32.length data in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ActiveElem {index = x; offset; etype = FuncRefType; init} @@ at],
+      [ActiveElem {etype = FuncRefType; data; index = x; offset} @@ at],
       [], [] }
   | elem_type LPAR ELEM elem_expr elem_expr_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
-      let init = (fun c -> $4 c :: $5 c) c in
-      let size = Lib.List32.length init in
+      let data = (fun c -> $4 c :: $5 c) c in
+      let size = Lib.List32.length data in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ActiveElem {index = x; offset; etype = FuncRefType; init} @@ at],
+      [ActiveElem {etype = FuncRefType; data; index = x; offset} @@ at],
       [], [] }
 
 data :
@@ -661,15 +666,15 @@ data :
  | LPAR DATA bind_var var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (bind_data c $3);
-     fun () -> ActiveData {index = $4 c memory; offset = $5 c; init = $6} @@ at }
+     fun () -> ActiveData {data = $6; index = $4 c memory; offset = $5 c} @@ at }
  | LPAR DATA var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (anon_data c);
-     fun () -> ActiveData {index = $3 c memory; offset = $4 c; init = $5} @@ at }
+     fun () -> ActiveData {data = $5; index = $3 c memory; offset = $4 c} @@ at }
  | LPAR DATA offset string_list RPAR  /* Sugar */
    { let at = at () in
      fun c -> ignore (anon_data c);
-     fun () -> ActiveData {index = 0l @@ at; offset = $3 c; init = $4} @@ at }
+     fun () -> ActiveData {data = $4; index = 0l @@ at; offset = $3 c} @@ at }
 
 memory :
   | LPAR MEMORY bind_var_opt memory_fields RPAR
@@ -693,7 +698,7 @@ memory_fields :
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
       let size = Int32.(div (add (of_int (String.length $3)) 65535l) 65536l) in
       [{mtype = MemoryType {min = size; max = Some size}} @@ at],
-      [ActiveData {index = x; offset; init = $3} @@ at],
+      [ActiveData {data = $3; index = x; offset} @@ at],
       [], [] }
 
 global :

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -601,28 +601,25 @@ elem :
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      ActiveElem {
-        etype = FuncRefType; data = $5 c func;
-        index = 0l @@ at; offset = $4 c
-      } @@ at }
+      { etype = FuncRefType; elems = $5 c func;
+        emode = Active {index = 0l @@ at; offset = $4 c} @@ at} @@ at }
   | LPAR ELEM bind_var_opt elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
-      fun () -> PassiveElem {etype = (fst $4); data = (snd $4) c} @@ at }
+      fun () ->
+      {etype = (fst $4); elems = (snd $4) c; emode = Passive @@ at} @@ at }
   | LPAR ELEM bind_var_opt table_use offset elem_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      ActiveElem {
-        etype = (fst $6); data = (snd $6) c;
-        index = $4 c table; offset = $5 c} @@ at }
+      { etype = (fst $6); elems = (snd $6) c;
+        emode = Active {index = $4 c table; offset = $5 c} @@ at} @@ at }
   | LPAR ELEM bind_var_opt offset elem_list RPAR  /* Sugar */
     { let at = at () in
       fun c -> ignore ($3 c anon_elem bind_elem);
       fun () ->
-      ActiveElem {
-        etype = (fst $5); data = (snd $5) c;
-        index = 0l @@ at; offset = $4 c} @@ at }
+      { etype = (fst $5); elems = (snd $5) c;
+        emode = Active {index = 0l @@ at; offset = $4 c} @@ at} @@ at }
 
 table :
   | LPAR TABLE bind_var_opt table_fields RPAR
@@ -644,37 +641,42 @@ table_fields :
   | elem_type LPAR ELEM elem_var_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
-      let data = $4 c func in
-      let size = Lib.List32.length data in
+      let elems = $4 c func in
+      let size = Lib.List32.length elems in
+      let emode = Active {index = x; offset} @@ at in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ActiveElem {etype = FuncRefType; data; index = x; offset} @@ at],
+      [{etype = FuncRefType; elems; emode} @@ at],
       [], [] }
   | elem_type LPAR ELEM elem_expr elem_expr_list RPAR  /* Sugar */
     { fun c x at ->
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
-      let data = (fun c -> $4 c :: $5 c) c in
-      let size = Lib.List32.length data in
+      let elems = (fun c -> $4 c :: $5 c) c in
+      let size = Lib.List32.length elems in
+      let emode = Active {index = x; offset} @@ at in
       [{ttype = TableType ({min = size; max = Some size}, $1)} @@ at],
-      [ActiveElem {etype = FuncRefType; data; index = x; offset} @@ at],
+      [{etype = FuncRefType; elems; emode} @@ at],
       [], [] }
 
 data :
   | LPAR DATA bind_var_opt string_list RPAR
     { let at = at () in
       fun c -> ignore ($3 c anon_data bind_data);
-      fun () -> PassiveData {data = $4} @@ at }
+      fun () -> {data = $4; dmode = Passive @@ at} @@ at }
  | LPAR DATA bind_var var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (bind_data c $3);
-     fun () -> ActiveData {data = $6; index = $4 c memory; offset = $5 c} @@ at }
+     fun () ->
+     {data = $6; dmode = Active {index = $4 c memory; offset = $5 c} @@ at} @@ at }
  | LPAR DATA var offset string_list RPAR
    { let at = at () in
      fun c -> ignore (anon_data c);
-     fun () -> ActiveData {data = $5; index = $3 c memory; offset = $4 c} @@ at }
+     fun () ->
+     {data = $5; dmode = Active {index = $3 c memory; offset = $4 c} @@ at} @@ at }
  | LPAR DATA offset string_list RPAR  /* Sugar */
    { let at = at () in
      fun c -> ignore (anon_data c);
-     fun () -> ActiveData {data = $4; index = 0l @@ at; offset = $3 c} @@ at }
+     fun () ->
+     {data = $4; dmode = Active {index = 0l @@ at; offset = $3 c} @@ at} @@ at }
 
 memory :
   | LPAR MEMORY bind_var_opt memory_fields RPAR
@@ -698,7 +700,7 @@ memory_fields :
       let offset = [i32_const (0l @@ at) @@ at] @@ at in
       let size = Int32.(div (add (of_int (String.length $3)) 65535l) 65536l) in
       [{mtype = MemoryType {min = size; max = Some size}} @@ at],
-      [ActiveData {data = $3; index = x; offset} @@ at],
+      [{data = $3; dmode = Active {index = x; offset} @@ at} @@ at],
       [], [] }
 
 global :

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -865,9 +865,9 @@ script_var_opt :
 script_module :
   | module_ { $1 }
   | LPAR MODULE module_var_opt BIN string_list RPAR
-    { $3, Encoded ("binary", $5) @@ at() }
+    { $3, Encoded ("binary:" ^ string_of_pos (at()).left, $5) @@ at() }
   | LPAR MODULE module_var_opt QUOTE string_list RPAR
-    { $3, Quoted ("quote", $5) @@ at() }
+    { $3, Quoted ("quote:" ^ string_of_pos (at()).left, $5) @@ at() }
 
 action :
   | LPAR INVOKE module_var_opt name const_list RPAR

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -422,26 +422,26 @@ let check_memory (c : context) (mem : memory) =
   let {mtype} = mem.it in
   check_memory_type mtype mem.at
 
-let check_elemref (c : context) (el : elem) =
+let check_elem_expr (c : context) (t : ref_type) (el : elem) =
   match el.it with
   | RefNull -> ()
   | RefFunc x -> ignore (func c x)
 
 let check_elem (c : context) (seg : table_segment) =
   match seg.it with
-  | ActiveElem {index; offset; init; _} ->
+  | PassiveElem {etype; data} ->
+    List.iter (check_elem_expr c etype) data
+  | ActiveElem {etype; data; index; offset} ->
     ignore (table c index);
     check_const c offset I32Type;
-    List.iter (check_elemref c) init
-  | PassiveElem {data; _} ->
-    List.iter (check_elemref c) data
+    List.iter (check_elem_expr c etype) data
 
 let check_data (c : context) (seg : memory_segment) =
   match seg.it with
-  | ActiveData {index; offset; init} ->
+  | PassiveData {data} -> ()
+  | ActiveData {data; index; offset} ->
     ignore (memory c index);
     check_const c offset I32Type
-  | PassiveData init -> ()
 
 let check_global (c : context) (glob : global) =
   let {gtype; value} = glob.it in

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -436,8 +436,8 @@ let check_elem_mode (c : context) (t : elem_type) (mode : segment_mode) =
     check_const c offset I32Type
 
 let check_elem (c : context) (seg : elem_segment) =
-  let {etype; elems; emode} = seg.it in
-  List.iter (check_elem_expr c etype) elems;
+  let {etype; einit; emode} = seg.it in
+  List.iter (check_elem_expr c etype) einit;
   check_elem_mode c etype emode
 
 let check_data_mode (c : context) (mode : segment_mode) =
@@ -448,13 +448,13 @@ let check_data_mode (c : context) (mode : segment_mode) =
     check_const c offset I32Type
 
 let check_data (c : context) (seg : data_segment) =
-  let {data; dmode} = seg.it in
+  let {dinit; dmode} = seg.it in
   check_data_mode c dmode
 
 let check_global (c : context) (glob : global) =
-  let {gtype; value} = glob.it in
+  let {gtype; ginit} = glob.it in
   let GlobalType (t, mut) = gtype in
-  check_const c value t
+  check_const c ginit t
 
 
 (* Modules *)

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -422,24 +422,26 @@ let check_memory (c : context) (mem : memory) =
   let {mtype} = mem.it in
   check_memory_type mtype mem.at
 
-let check_elem_expr (c : context) (t : ref_type) (el : elem) =
-  match el.it with
+let check_elem_expr (c : context) (t : elem_type) (e : elem_expr) =
+  match e.it with
   | RefNull -> ()
   | RefFunc x -> ignore (func c x)
 
-let check_elem (c : context) (seg : table_segment) =
-  match seg.it with
-  | PassiveElem {etype; data} ->
-    List.iter (check_elem_expr c etype) data
-  | ActiveElem {etype; data; index; offset} ->
+let check_elem (c : context) (seg : elem_segment) =
+  let {etype; elems; emode} = seg.it in
+  match emode.it with
+  | Passive ->
+    List.iter (check_elem_expr c etype) elems
+  | Active {index; offset} ->
     ignore (table c index);
     check_const c offset I32Type;
-    List.iter (check_elem_expr c etype) data
+    List.iter (check_elem_expr c etype) elems
 
-let check_data (c : context) (seg : memory_segment) =
-  match seg.it with
-  | PassiveData {data} -> ()
-  | ActiveData {data; index; offset} ->
+let check_data (c : context) (seg : data_segment) =
+  let {data; dmode} = seg.it in
+  match dmode.it with
+  | Passive -> ()
+  | Active {index; offset} ->
     ignore (memory c index);
     check_const c offset I32Type
 


### PR DESCRIPTION
Refactor segment representation in AST (in both spec and interpreter) by separating out a `segment_mode`.

Other changes in Spec:
- Various fixes to text format grammar of segments.
- Factor out elemkind in binary format.
- Add note about possible future extension of element kinds.
- Add note about interpretation of segment kinds as bitfields.
- Fix some cross references.

Other changes in Interpreter:
- Rename {table,memory}_segment to {elem,data}_segment.
- Some rename elem to elem_expr and global.value to global.ginit for consistency with spec.
- Decode the elem segment kind as vu32 to maintain backwards compat.
- Some code simplifications / beautifications.