### PR TITLE
[interpreter/test] Update table.init semantics as well

### DIFF
--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -202,11 +202,17 @@ let rec step (c : config) : config =
         with Global.NotMutable -> Crash.error e.at "write to immutable global"
            | Global.Type -> Crash.error e.at "type mismatch at global write")
 
+      | TableCopy, I32 0l :: I32 s :: I32 d :: vs' ->
+        vs', []
+
       (* TODO: turn into small-step, but needs reference values *)
       | TableCopy, I32 n :: I32 s :: I32 d :: vs' ->
         let tab = table frame.inst (0l @@ e.at) in
         (try Table.copy tab d s n; vs', []
         with exn -> vs', [Trapping (table_error e.at exn) @@ e.at])
+
+      | TableInit x, I32 0l :: I32 s :: I32 d :: vs' ->
+        vs', []
 
       (* TODO: turn into small-step, but needs reference values *)
       | TableInit x, I32 n :: I32 s :: I32 d :: vs' ->

--- a/test/core/bulk.wast
+++ b/test/core/bulk.wast
@@ -220,20 +220,24 @@
   (elem $a (table 0) (i32.const 0) func $f)
 
   (func (export "drop_passive") (elem.drop $p))
-  (func (export "init_passive")
-    (table.init $p (i32.const 0) (i32.const 0) (i32.const 0)))
+  (func (export "init_passive") (param $len i32)
+    (table.init $p (i32.const 0) (i32.const 0) (local.get $len))
+  )
 
   (func (export "drop_active") (elem.drop $a))
-  (func (export "init_active")
-    (table.init $a (i32.const 0) (i32.const 0) (i32.const 0)))
+  (func (export "init_active") (param $len i32)
+    (table.init $a (i32.const 0) (i32.const 0) (local.get $len))
+  )
 )
 
-(invoke "init_passive")
+(invoke "init_passive" (i32.const 1))
 (invoke "drop_passive")
 (assert_trap (invoke "drop_passive") "element segment dropped")
-(assert_trap (invoke "init_passive") "element segment dropped")
+(assert_return (invoke "init_passive" (i32.const 0)))
+(assert_trap (invoke "init_passive" (i32.const 1)) "element segment dropped")
 (assert_trap (invoke "drop_active") "element segment dropped")
-(assert_trap (invoke "init_active") "element segment dropped")
+(assert_return (invoke "init_active" (i32.const 0)))
+(assert_trap (invoke "init_active" (i32.const 1)) "element segment dropped")
 
 
 ;; table.copy


### PR DESCRIPTION
In interpreter & test, table.init still trapped if segment has been dropped but length parameter was 0.