### PR TITLE
Fix expected validation errors for `elem.drop`

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -261,7 +261,6 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     [I32Type; I32Type; I32Type] --> []
 
   | ElemDrop x ->
-    ignore (table c (0l @@ e.at));
     ignore (elem c x);
     [] --> []
 
@@ -295,7 +294,6 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     [I32Type; I32Type; I32Type] --> []
 
   | DataDrop x ->
-    ignore (memory c (0l @@ e.at));
     ignore (data c x);
     [] --> []
 

--- a/test/core/memory_init.wast
+++ b/test/core/memory_init.wast
@@ -189,7 +189,7 @@
    (module
      (func (export "test")
        (data.drop 0)))
-   "unknown memory 0")
+   "unknown data segment")
 
 (assert_invalid
   (module

--- a/test/core/table_init.wast
+++ b/test/core/table_init.wast
@@ -193,7 +193,7 @@
   (module
     (func (export "test")
       (elem.drop 0)))
-  "unknown element segment 0")
+  "unknown elem segment 0")
 
 (assert_invalid
   (module
@@ -207,7 +207,7 @@
     (func (result i32) (i32.const 0))
     (func (export "test")
       (elem.drop 4)))
-  "unknown element segment 4")
+  "unknown elem segment 4")
 
 (assert_invalid
   (module

--- a/test/core/table_init.wast
+++ b/test/core/table_init.wast
@@ -193,7 +193,7 @@
   (module
     (func (export "test")
       (elem.drop 0)))
-  "unknown table 0")
+  "unknown element segment 0")
 
 (assert_invalid
   (module
@@ -207,7 +207,7 @@
     (func (result i32) (i32.const 0))
     (func (export "test")
       (elem.drop 4)))
-  "unknown table 0")
+  "unknown element segment 4")
 
 (assert_invalid
   (module


### PR DESCRIPTION
The validation for `elem.drop` only checks that the referenced segment is valid within the context, it does not check the existence of tables. Therefore, when asserting that a module is invalid because of a bad segment index in `elem.drop`, we should expect an error message that references an unknown element segment, not a message that references an unknown table.