### PR TITLE
Test that partially out of bounds segments don't write to a memory/table

### DIFF
--- a/test/core/linking.wast
+++ b/test/core/linking.wast
@@ -231,11 +231,12 @@
     (table (import "Mt" "tab") 10 funcref)
     (func $f (result i32) (i32.const 0))
     (elem (i32.const 7) $f)
-    (elem (i32.const 12) $f)  ;; out of bounds
+    (elem (i32.const 8) $f $f $f $f $f)  ;; (partially) out of bounds
   )
   "out of bounds"
 )
 (assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))
+(assert_trap (invoke $Mt "call" (i32.const 8)) "uninitialized")
 
 (assert_trap
   (module
@@ -337,13 +338,15 @@
 ;; after the instantiation failure.
 (assert_trap
   (module
+    ;; Note: the memory is 5 pages large by the time we get here.
     (memory (import "Mm" "mem") 1)
     (data (i32.const 0) "abc")
-    (data (i32.const 0x50000) "d") ;; out of bounds
+    (data (i32.const 327670) "zzzzzzzzzzzzzzzzzz") ;; (partially) out of bounds
   )
   "out of bounds"
 )
 (assert_return (invoke $Mm "load" (i32.const 0)) (i32.const 97))
+(assert_return (invoke $Mm "load" (i32.const 327670)) (i32.const 0))
 
 (assert_trap
   (module


### PR DESCRIPTION
Fixes #138