### PR TITLE
Fix {memory,table}.init immediate order

### DIFF
--- a/document/core/binary/instructions.rst
+++ b/document/core/binary/instructions.rst
@@ -122,7 +122,7 @@ Each variant of :ref:`table instruction <syntax-instr-table>` is encoded with a 
 .. math::
    \begin{array}{llclll}
    \production{instruction} & \Binstr &::=& \dots \\ &&|&
-     \hex{FC}~\hex{0C}~~\hex{00}~x{:}\Belemidx &\Rightarrow& \TABLEINIT~x \\ &&|&
+     \hex{FC}~\hex{0C}~~x{:}\Belemidx~\hex{00} &\Rightarrow& \TABLEINIT~x \\ &&|&
      \hex{FC}~\hex{0D}~~x{:}\Belemidx &\Rightarrow& \ELEMDROP~x \\ &&|&
      \hex{FC}~\hex{0E}~~\hex{00}~~\hex{00} &\Rightarrow& \TABLECOPY \\
    \end{array}
@@ -182,7 +182,7 @@ Each variant of :ref:`memory instruction <syntax-instr-memory>` is encoded with 
      \hex{3E}~~m{:}\Bmemarg &\Rightarrow& \I64.\STORE\K{32}~m \\ &&|&
      \hex{3F}~~\hex{00} &\Rightarrow& \MEMORYSIZE \\ &&|&
      \hex{40}~~\hex{00} &\Rightarrow& \MEMORYGROW \\ &&|&
-     \hex{FC}~\hex{08}~~\hex{00}~x{:}\Bdataidx &\Rightarrow& \MEMORYINIT~x \\ &&|&
+     \hex{FC}~\hex{08}~~x{:}\Bdataidx~\hex{00} &\Rightarrow& \MEMORYINIT~x \\ &&|&
      \hex{FC}~\hex{09}~~x{:}\Bdataidx &\Rightarrow& \DATADROP~x \\ &&|&
      \hex{FC}~\hex{0A}~~\hex{00}~~\hex{00} &\Rightarrow& \MEMORYCOPY \\ &&|&
      \hex{FC}~\hex{0B}~~\hex{00} &\Rightarrow& \MEMORYFILL \\


### PR DESCRIPTION
The data/elem index comes before the memory/table index.

Fixes #146.