### PR TITLE
[test] Fix table index encoding

### DIFF
--- a/test/core/binary-leb128.wast
+++ b/test/core/binary-leb128.wast
@@ -33,9 +33,10 @@
   "\00asm" "\01\00\00\00"
   "\04\04\01"                          ;; Table section with 1 entry
   "\70\00\00"                          ;; no max, minimum 0, funcref
-  "\09\07\01"                          ;; Element section with 1 entry
+  "\09\09\01"                          ;; Element section with 1 entry
+  "\02"                                ;; Element with explicit table index
   "\80\00"                             ;; Table index 0, encoded with 2 bytes
-  "\41\00\0b\00"                       ;; (i32.const 0) with no elements
+  "\41\00\0b\00\00"                    ;; (i32.const 0) with no elements
 )
 (module binary
   "\00asm" "\01\00\00\00"


### PR DESCRIPTION
The encoding of the table index in binary-leb128.wast is incorrect with the bulk-memory extensions, see https://github.com/WebAssembly/bulk-memory-operations/issues/153. I saw and fixed the issue first in the reference types proposal (see https://github.com/WebAssembly/reference-types/pull/95), but apparently it also exists here.